### PR TITLE
Fixes an issue where if a property for bootstrapFixtures was not defined it would still run

### DIFF
--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -670,11 +670,11 @@ export default class LanguageController {
     }
 
     async getExpression(ref: ExpressionRef): Promise<Expression | null> {
-        if(bootstrapFixtures && ref.language.address === "neighbourhood") {
+        if(bootstrapFixtures?.perspectives && ref.language.address === "neighbourhood") {
             const fixturePerspective = bootstrapFixtures.perspectives!.find(f=>f.address===ref.expression)
             if(fixturePerspective && fixturePerspective.expression) return fixturePerspective.expression
         }
-        if(bootstrapFixtures && ref.language.address === "lang") {
+        if(bootstrapFixtures?.languages && ref.language.address === "lang") {
             const fixtureLang = bootstrapFixtures.languages!.find(f=>f.address===ref.expression)
             if(fixtureLang && fixtureLang.meta) return fixtureLang.meta
         }


### PR DESCRIPTION
Fixes an issue where if a property for `bootstrapFixtures` was not defined it would still run causing it to return `undefined`.