### PR TITLE
Expression caching on get()

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "fs-extra": "^10.0.0",
     "@holochain/conductor-api": "0.2.4",
-    "@perspect3vism/ad4m": "0.1.24",
+    "@perspect3vism/ad4m": "0.1.25",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",

--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -707,7 +707,7 @@ export default class LanguageController {
             } else {
                 console.log("Cache miss...");
                 expr = await lang.expressionAdapter.get(ref.expression);
-                this.#db.addExpression(ref.expression, expr);
+                if (expr) { this.#db.addExpression(ref.expression, expr) };
             };
         } else {
             expr = await lang.expressionAdapter.get(ref.expression);

--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -1,6 +1,6 @@
 import { 
     Address, Expression, Language, LanguageContext, 
-    LinksAdapter, InteractionCall, PublicSharing, ReadOnlyLanguage, LanguageMetaInternal, LanguageMetaInput, PerspectiveExpression, parseExprUrl 
+    LinksAdapter, InteractionCall, PublicSharing, ReadOnlyLanguage, LanguageMetaInternal, LanguageMetaInput, PerspectiveExpression 
 } from '@perspect3vism/ad4m';
 import { ExpressionRef, LanguageRef, LanguageExpression, LanguageLanguageInput } from '@perspect3vism/ad4m';
 import fs from 'fs'

--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -1,6 +1,6 @@
 import { 
     Address, Expression, Language, LanguageContext, 
-    LinksAdapter, InteractionCall, PublicSharing, ReadOnlyLanguage, LanguageMetaInternal, LanguageMetaInput, PerspectiveExpression 
+    LinksAdapter, InteractionCall, PublicSharing, ReadOnlyLanguage, LanguageMetaInternal, LanguageMetaInput, PerspectiveExpression, parseExprUrl 
 } from '@perspect3vism/ad4m';
 import { ExpressionRef, LanguageRef, LanguageExpression, LanguageLanguageInput } from '@perspect3vism/ad4m';
 import fs from 'fs'
@@ -12,12 +12,22 @@ import { builtInLangs, builtInLangPath, languageAliases, bootstrapFixtures } fro
 import * as PubSub from './graphQL-interface/PubSub'
 import yaml from "js-yaml";
 import { v4 as uuidv4 } from 'uuid'
+import RuntimeService from './RuntimeService';
+import Signatures from './agent/Signatures';
+import { PerspectivismDb } from './db';
 
 type LinkObservers = (added: Expression[], removed: Expression[], lang: LanguageRef)=>void;
 
 interface LoadedLanguage {
     language: Language,
     hash: string,
+}
+
+interface Services {
+    holochainService: HolochainService, 
+    runtimeService: RuntimeService, 
+    signatures: Signatures, 
+    db: PerspectivismDb
 }
 
 export default class LanguageController {
@@ -27,6 +37,9 @@ export default class LanguageController {
     #linkObservers: LinkObservers[];
     #holochainService: HolochainService
     #builtInLanguages: string[];
+    #runtimeService: RuntimeService;
+    #signatures: Signatures;
+    #db: PerspectivismDb;
 
     #agentLanguage?: Language
     #languageLanguage?: Language
@@ -34,11 +47,14 @@ export default class LanguageController {
     pubSub
 
 
-    constructor(context: object, holochainService: HolochainService) {
+    constructor(context: object, services: Services) {
         this.#builtInLanguages = builtInLangs.map(l => `${builtInLangPath}/${l}/build/bundle.js`)
 
         this.#context = context
-        this.#holochainService = holochainService
+        this.#holochainService = services.holochainService
+        this.#runtimeService = services.runtimeService
+        this.#signatures = services.signatures
+        this.#db = services.db
         this.#languages = new Map()
         this.#languageConstructors = new Map()
         this.#linkObservers = []   
@@ -243,8 +259,7 @@ export default class LanguageController {
             }
             const languageMetaData = languageMeta.data as LanguageExpression;
             const languageAuthor = languageMeta.author;
-            //@ts-ignore
-            const trustedAgents: string[] = this.#context.runtime.getTrustedAgents();
+            const trustedAgents: string[] = this.#runtimeService.getTrustedAgents();
             //Check if the author of the language is in the trusted agent list the current agent holds, if so then go ahead and install
             if (trustedAgents.find((agent) => agent === languageAuthor)) {
                 //Get the language source so we can generate a hash and check against the hash given in the language meta information
@@ -283,8 +298,7 @@ export default class LanguageController {
                 if (!sourceLanguageMeta) {
                     throw new Error("Could not get the meta for the source language");
                 }
-                //@ts-ignore
-                const trustedAgents: string[] = this.#context.runtime.getTrustedAgents();
+                const trustedAgents: string[] = this.#runtimeService.getTrustedAgents();
                 //Check that the agent who authored the original template language is in the current agents trust list
                 if (trustedAgents.find((agent) => agent === sourceLanguageMeta.author)) {
                     //Apply the template information supplied in the language to be installed to the source language and make sure that the resulting
@@ -682,11 +696,25 @@ export default class LanguageController {
         if (!lang.expressionAdapter) {
             throw Error("Language does not have an expresionAdapter!")
         };
-        const expr = await lang.expressionAdapter.get(ref.expression);
+        const langIsImmutable = await this.isImmutableExpression(ref);
+        let expr;
+        if (langIsImmutable) {
+            console.log("Calling cache for expression...");
+            const cachedExpression = this.#db.getExpression(ref.expression);
+            if (cachedExpression) {
+                console.log("Cache hit...");
+                expr = cachedExpression
+            } else {
+                console.log("Cache miss...");
+                expr = await lang.expressionAdapter.get(ref.expression);
+                this.#db.addExpression(ref.expression, expr);
+            };
+        } else {
+            expr = await lang.expressionAdapter.get(ref.expression);
+        }
         if(expr) {
             try{
-                // @ts-ignore
-                if(! await this.#context.signatures.verify(expr)) {
+                if(! await this.#signatures.verify(expr)) {
                     console.error(new Date().toISOString(), "BROKEN SIGNATURE FOR EXPRESSION:", expr)
                     expr.proof.invalid = true
                     delete expr.proof.valid
@@ -736,7 +764,7 @@ export default class LanguageController {
     }
 }
 
-export function init(context: object, holochainService: HolochainService): LanguageController {
-    const languageController = new LanguageController(context, holochainService)
+export function init(context: object, services: Services): LanguageController {
+    const languageController = new LanguageController(context, services)
     return languageController
 }

--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -725,6 +725,15 @@ export default class LanguageController {
     addLinkObserver(observer: LinkObservers) {
         this.#linkObservers.push(observer)
     }
+
+    async isImmutableExpression(ref: ExpressionRef): Promise<boolean> {
+        const language = await this.languageByRef(ref.language);
+        if (!language.isImmutableExpression) {
+            return true
+        } else {
+            return language.isImmutableExpression(ref.expression);
+        }
+    }
 }
 
 export function init(context: object, holochainService: HolochainService): LanguageController {

--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -729,7 +729,7 @@ export default class LanguageController {
     async isImmutableExpression(ref: ExpressionRef): Promise<boolean> {
         const language = await this.languageByRef(ref.language);
         if (!language.isImmutableExpression) {
-            return true
+            return false
         } else {
             return language.isImmutableExpression(ref.expression);
         }

--- a/src/core/PerspectivismCore.ts
+++ b/src/core/PerspectivismCore.ts
@@ -185,8 +185,8 @@ export default class PerspectivismCore {
             runtime: this.#runtimeService,
             IPFS: this.#IPFS,
             signatures: this.#signatures,
-            ad4mSignal: this.languageSignal
-        }, this.#holochain!)
+            ad4mSignal: this.languageSignal,
+        }, { holochainService: this.#holochain!, runtimeService: this.#runtimeService, signatures: this.#signatures, db: this.#db } )
 
         this.#perspectivesController = new PerspectivesController(Config.rootConfigPath, {
             db: this.#db,

--- a/src/core/PerspectivismCore.ts
+++ b/src/core/PerspectivismCore.ts
@@ -99,6 +99,10 @@ export default class PerspectivismCore {
         return this.#languageController!
     }
 
+    get database(): PerspectivismDb {
+        return this.#db
+    }
+
     async exit() {
         console.log("Exiting gracefully...")
         console.log("Stopping Prolog engines")

--- a/src/core/db.test.ts
+++ b/src/core/db.test.ts
@@ -1,6 +1,7 @@
 import { PerspectivismDb } from './db'
 import Memory from 'lowdb/adapters/Memory'
 import { v4 as uuidv4 } from 'uuid'
+import { Expression } from '@perspect3vism/ad4m'
 
 describe('PerspectivismDb', () => {
     let db: PerspectivismDb | undefined
@@ -161,5 +162,12 @@ describe('PerspectivismDb', () => {
         const result2 = db!.getLinksByTarget(pUUID!, '1')
 
         expect(result2).toEqual([])
+    })
+
+    it('can add expression object', () => {
+        const expression = new Expression();
+        db!.addExpression("address", expression);
+        const getExpression = db!.getExpression("address");
+        expect(getExpression).toBe(expression);
     })
 })

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -1,7 +1,7 @@
 import low from 'lowdb'
 import FileSync from 'lowdb/adapters/FileSync'
 import path from 'path'
-import type { LinkExpression } from "@perspect3vism/ad4m";  
+import type { Expression, LinkExpression } from "@perspect3vism/ad4m";  
 
 export class PerspectivismDb {
     #db: any
@@ -127,6 +127,13 @@ export class PerspectivismDb {
         this.#db.get(key).remove(l => l===linkName).write()
     }
 
+    addExpression(key: string, expression: Expression): void {
+        this.#db.set(key, expression).write()
+    }
+
+    getExpression(key: string): Expression | undefined {
+        return this.#db.get(key).value()
+    }
 }
 
 export function init(dbFilePath: string): PerspectivismDb {

--- a/src/core/graphQL-interface/GraphQL.ts
+++ b/src/core/graphQL-interface/GraphQL.ts
@@ -35,19 +35,12 @@ function createResolvers(core: PerspectivismCore) {
             expression: async (parent, args, context, info) => {
                 const url = args.url.toString();
                 const ref = parseExprUrl(url)
-                if (await core.languageController.isImmutableExpression(ref)) {
-                    const cachedExpression = core.database.getExpression(url);
-                    if (cachedExpression) {
-                        return cachedExpression
-                    }
-                }
                 const expression = await core.languageController.getExpression(ref);
                 if(expression) {
                     expression.ref = ref
                     expression.url = url
                     expression.data = JSON.stringify(expression.data)
                 }
-                core.database.addExpression(url, expression);
                 return expression
             },
             //@ts-ignore

--- a/src/core/graphQL-interface/GraphQL.ts
+++ b/src/core/graphQL-interface/GraphQL.ts
@@ -33,13 +33,21 @@ function createResolvers(core: PerspectivismCore) {
             },
             //@ts-ignore
             expression: async (parent, args, context, info) => {
-                const ref = parseExprUrl(args.url.toString())
-                const expression = await core.languageController.getExpression(ref) as any
+                const url = args.url.toString();
+                const ref = parseExprUrl(url)
+                if (await core.languageController.isImmutableExpression(ref)) {
+                    const cachedExpression = core.database.getExpression(url);
+                    if (cachedExpression) {
+                        return cachedExpression
+                    }
+                }
+                const expression = await core.languageController.getExpression(ref);
                 if(expression) {
                     expression.ref = ref
-                    expression.url = args.url.toString()
+                    expression.url = url
                     expression.data = JSON.stringify(expression.data)
                 }
+                core.database.addExpression(url, expression);
                 return expression
             },
             //@ts-ignore


### PR DESCRIPTION
Uses current PerspectivismDB....

Depends on: https://github.com/perspect3vism/ad4m/pull/32 

If language is found not have the `isImmutableExpression()` adapter then we count this language to be mutable by default...