### PR TITLE
Allows languages to avoid exporting name value

### DIFF
--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -154,10 +154,16 @@ export default class LanguageController {
         // @ts-ignore
         const hash = await this.ipfsHash(bundleBytes)
         
-        const { default: create, name } = require(sourceFilePath)
+        const languageSource = require(sourceFilePath)
+        let create;
+        if (!languageSource.default) {
+            create = languageSource;
+        } else {
+            create =  languageSource.default;
+        }
 
         const customSettings = this.getSettings(hash)
-        const storageDirectory = this.getLanguageStoragePath(name)
+        const storageDirectory = this.getLanguageStoragePath(hash)
         const Holochain = this.#holochainService.getDelegateForLanguage(hash)
         //@ts-ignore
         const ad4mSignal = this.#context.ad4mSignal.bind({language: hash, pubsub: this.pubSub});
@@ -166,7 +172,7 @@ export default class LanguageController {
         if(language.linksAdapter) {
             language.linksAdapter.addCallback((added: Expression[], removed: Expression[]) => {
                 this.#linkObservers.forEach(o => {
-                    o(added, removed, {name, address: hash} as LanguageRef)
+                    o(added, removed, {name: language.name, address: hash} as LanguageRef)
                 })
             })
         }

--- a/src/tests/test-language/index.ts
+++ b/src/tests/test-language/index.ts
@@ -1,7 +1,5 @@
 import type { Address, Interaction, Expression, Language, LanguageContext, PublicSharing } from "@perspect3vism/ad4m";
 
-export const name: string = "test-language"
-
 export default function create(context: LanguageContext): Language {
     const expressions = new Array<Expression>()
 
@@ -25,7 +23,7 @@ export default function create(context: LanguageContext): Language {
     }
 
     return {
-        name,
+        name: "test-language",
         interactions,
         expressionAdapter: {
             get: async (address: Address) => expressions[parseInt(address)],


### PR DESCRIPTION
Removes requirement for languages to export a name & instead rely on name returned from LanguageObject.

This was required since a language I am currently developing has some `node_modules` which use `const name` and thus a conflict is caused.