### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,12 +10,13 @@ on:
   pull_request:
 
 jobs:
-  build:
-
+  test-linux:
+    name: Linux Test
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
+        platform: [macos-10.14, ubuntu-18.04]
         node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
@@ -38,3 +39,51 @@ jobs:
     - run: npm i
     - run: npm run build --if-present
     - run: npm test
+
+  test-windows:
+    name: Windows Test
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+      - name: Cache cargo
+        id: cache-cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-cargo
+      - name: Choco install InnoSetup
+        uses: ./
+        with:
+          args: install swi-prolog
+      - name: Build Holochain
+        env:
+          SQLCIPHER_STATIC: 1
+        run: |
+          rustup target add wasm32-unknown-unknown
+          (cargo install lair_keystore --version 0.0.9 || true)
+          (cargo install --locked holochain --git https://github.com/holochain/holochain.git --tag holochain-0.0.127 || true)
+          (cargo install holochain_cli --version 0.0.28 || true)
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm install -g npm
+      - run: npm i
+      - run: npm run build --if-present
+      - run: npm test:windows

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [macos-10.14, ubuntu-18.04]
+        platform: [macos-10.15, ubuntu-18.04]
         node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
@@ -87,4 +87,4 @@ jobs:
       - run: npm install -g npm
       - run: npm i
       - run: npm run build --if-present
-      - run: npm test:windows
+      - run: npm run test:windows

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -67,7 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo
-      - name: Choco install InnoSetup
+      - name: Choco install swipl-prolog
         uses: crazy-max/ghaction-chocolatey@v1
         with:
           args: install swi-prolog

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -67,18 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo
-      - run: $env:path
-      - name: Choco install swipl-prolog
-        run: |
-          choco install swi-prolog
-          $env:path += ";C:\Program Files\swipl\bin"
-          refreshenv
-          $env:path
-          Get-Command swipl
-      - run: $env:path += ";C:\Program Files\swipl\bin"
-      - run: refreshenv
-      - run: $env:path
-      - run: Get-Command swipl
+
       - name: Build Holochain
         env:
           SQLCIPHER_STATIC: 1
@@ -87,15 +76,18 @@ jobs:
           (cargo install lair_keystore --version 0.0.9 || true)
           (cargo install --locked holochain --git https://github.com/holochain/holochain.git --tag holochain-0.0.127 || true)
           (cargo install holochain_cli --version 0.0.28 || true)
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: $env:path
-      - run: refreshenv
-      - run: $env:path
       - run: npm install -g npm
       - run: npm i
-      - run: npm run build --if-present
-      - run: npm run test:windows
+
+      - name: Choco install swipl-prolog
+        run: |
+          choco install swi-prolog
+          $env:path += ";C:\Program Files\swipl\bin"
+          npm run build --if-present
+          npm run test:windows

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -69,9 +69,7 @@ jobs:
             ${{ runner.os }}-cargo
       - run: $env:path
       - name: Choco install swipl-prolog
-        uses: crazy-max/ghaction-chocolatey@v1.7.0
-        with:
-          args: install swi-prolog
+        run: choco install swi-prolog
       - run: $env:path += ";C:\Program Files\swipl\bin"
       - run: refreshenv
       - run: $env:path

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo
       - name: Choco install swipl-prolog
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@v1.7.0
         with:
           args: install swi-prolog
       - name: Build Holochain
@@ -84,7 +84,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - run: $env:path
       - run: refreshenv
+      - run: $env:path
       - run: npm install -g npm
       - run: npm i
       - run: npm run build --if-present

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [macos-latest, ubuntu-18.04]
+        platform: [macos-10.15, ubuntu-18.04]
         node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -67,10 +67,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo
+      - run: $env:path
       - name: Choco install swipl-prolog
         uses: crazy-max/ghaction-chocolatey@v1.7.0
         with:
           args: install swi-prolog
+      - run: refreshenv
+      - run: $env:path
       - name: Build Holochain
         env:
           SQLCIPHER_STATIC: 1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -72,8 +72,9 @@ jobs:
         uses: crazy-max/ghaction-chocolatey@v1.7.0
         with:
           args: install swi-prolog
+      - run: $env:path += ";C:\Program Files\swipl\bin"
       - run: refreshenv
-      - run: $env:path
+      - run: Get-Command swipl.exe
       - name: Build Holochain
         env:
           SQLCIPHER_STATIC: 1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [macos-10.15, ubuntu-18.04]
+        platform: [macos-latest, ubuntu-18.04]
         node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
@@ -85,7 +85,7 @@ jobs:
       - run: npm install -g npm
       - run: npm i
 
-      - name: Choco install swipl-prolog
+      - name: Test
         run: |
           choco install swi-prolog
           $env:path += ";C:\Program Files\swipl\bin"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -74,7 +74,8 @@ jobs:
           args: install swi-prolog
       - run: $env:path += ";C:\Program Files\swipl\bin"
       - run: refreshenv
-      - run: Get-Command swipl.exe
+      - run: $env:path
+      - run: Get-Command swipl
       - name: Build Holochain
         env:
           SQLCIPHER_STATIC: 1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,15 +10,16 @@ on:
   pull_request:
 
 jobs:
-  test-linux:
+  test:
     name: Linux Test
-    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         platform: [macos-10.14, ubuntu-18.04]
         node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    name: Linux Test
+    name: Test
 
     strategy:
       matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo
       - name: Choco install InnoSetup
-        uses: ./
+        uses: crazy-max/ghaction-chocolatey@v1
         with:
           args: install swi-prolog
       - name: Build Holochain

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+      - run: refreshenv
       - run: npm install -g npm
       - run: npm i
       - run: npm run build --if-present

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [macos-10.15, ubuntu-18.04]
+        platform: [ubuntu-18.04]
         node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -69,7 +69,12 @@ jobs:
             ${{ runner.os }}-cargo
       - run: $env:path
       - name: Choco install swipl-prolog
-        run: choco install swi-prolog
+        run: |
+          choco install swi-prolog
+          $env:path += ";C:\Program Files\swipl\bin"
+          refreshenv
+          $env:path
+          Get-Command swipl
       - run: $env:path += ";C:\Program Files\swipl\bin"
       - run: refreshenv
       - run: $env:path

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,5 @@
+# Update windows holochain version in github CI as its not using nix
+
 {
   holonixPath ?  builtins.fetchTarball { url = "https://github.com/holochain/holonix/archive/52158409f9b76b442e592e8f06632b0e57a6c365.tar.gz"; }
 }:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test-all": "PATH=$PATH:./src/test-temp jest --forceExit",
     "test-all:windows": "powershell ./scripts/run-all-test.ps1 & jest --forceExit",
     "test": "npm run prepare-test && nix-shell --run \"npm run test-all\" && node scripts/cleanTestingData.js",
-    "test:windows": "npm run test-all:windows && node scripts/cleanTestingData.js"
+    "test:windows": "npm run prepare-test:windows && npm run test-all:windows && node scripts/cleanTestingData.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "run": "node lib/main.js",
     "prepare-test": "rm -rf src/test-temp && ./scripts/build-test-language.sh && nix-shell --run ./scripts/prepareTestDirectory.sh && node scripts/get-builtin-test-langs.js && npm run inject-language-language && npm run publish-test-languages && npm run inject-publishing-agent",
-    "prepare-test:windows": "rm -rf src/test-temp && powershell ./scripts/build-test-language.ps1 && powershell ./scripts/prepareTestDirectory.ps1 && node scripts/get-builtin-test-langs.js && npm run inject-language-language && npm run publish-test-languages && npm run inject-publishing-agent",
+    "prepare-test:windows": "powershell ./scripts/build-test-language.ps1 && powershell ./scripts/prepareTestDirectory.ps1 && node scripts/get-builtin-test-langs.js && npm run inject-language-language && npm run publish-test-languages && npm run inject-publishing-agent",
     "inject-language-language": "node scripts/injectLanguageLanguageBundle.js",
     "inject-publishing-agent": "node scripts/injectPublishingAgent.js",
     "publish-test-languages": "npm run build && node ./lib/tests/publishTestLangs.js",
@@ -24,7 +24,7 @@
     "test-all": "PATH=$PATH:./src/test-temp jest --forceExit",
     "test-all:windows": "powershell ./scripts/run-all-test.ps1 & jest --forceExit",
     "test": "npm run prepare-test && nix-shell --run \"npm run test-all\" && node scripts/cleanTestingData.js",
-    "test:windows": "prepare-test:windows && npm run test-all:windows && node scripts/cleanTestingData.js"
+    "test:windows": "npm run test-all:windows && node scripts/cleanTestingData.js"
   },
   "repository": {
     "type": "git",
@@ -84,7 +84,7 @@
     "node-fetch": "^2.6.1",
     "sha256": "^0.2.0",
     "sha3": "^2.1.3",
-    "swipl-stdio": "^1.0.4",
+    "swipl-stdio": "https://github.com/perspect3vism/node-swipl-stdio.git",
     "tmp": "^0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,13 +15,16 @@
   "scripts": {
     "build": "tsc",
     "run": "node lib/main.js",
-    "prepare-test": "rm -rf src/test-temp && ./scripts/build-test-language.sh &&  nix-shell --run ./scripts/prepareTestDirectory.sh && node scripts/get-builtin-test-langs.js && npm run inject-language-language && npm run publish-test-languages && npm run inject-publishing-agent",
+    "prepare-test": "rm -rf src/test-temp && ./scripts/build-test-language.sh && nix-shell --run ./scripts/prepareTestDirectory.sh && node scripts/get-builtin-test-langs.js && npm run inject-language-language && npm run publish-test-languages && npm run inject-publishing-agent",
+    "prepare-test:windows": "rm -rf src/test-temp && powershell ./scripts/build-test-language.ps1 && powershell ./scripts/prepareTestDirectory.ps1 && node scripts/get-builtin-test-langs.js && npm run inject-language-language && npm run publish-test-languages && npm run inject-publishing-agent",
     "inject-language-language": "node scripts/injectLanguageLanguageBundle.js",
     "inject-publishing-agent": "node scripts/injectPublishingAgent.js",
     "publish-test-languages": "npm run build && node ./lib/tests/publishTestLangs.js",
     "test-integration": "jest --forceExit src/tests/integration.test.ts",
     "test-all": "PATH=$PATH:./src/test-temp jest --forceExit",
-    "test": "npm run prepare-test && nix-shell --run \"npm run test-all\" && node scripts/cleanTestingData.js"
+    "test-all:windows": "powershell ./scripts/run-all-test.ps1 & jest --forceExit",
+    "test": "npm run prepare-test && nix-shell --run \"npm run test-all\" && node scripts/cleanTestingData.js",
+    "test:windows": "prepare-test:windows && npm run test-all:windows && node scripts/cleanTestingData.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-test-language.ps1
+++ b/scripts/build-test-language.ps1
@@ -1,5 +1,4 @@
-#!/bin/bash
-
-cd src/tests/test-language
+Remove-Item -Recurse -Force src/test-temp
+Set-Location src/tests/test-language
 npm i
 npm run build

--- a/scripts/build-test-language.ps1
+++ b/scripts/build-test-language.ps1
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd src/tests/test-language
+npm i
+npm run build

--- a/scripts/prepareTestDirectory.ps1
+++ b/scripts/prepareTestDirectory.ps1
@@ -26,5 +26,5 @@ Copy-Item $LkPath -Destination lair-keystore.exe
 if (Test-Path swipl.exe) {
   Remove-Item swipl.exe
 }
-$LkPath = Get-Command swipl.exe | Select-Object -ExpandProperty Definition
-Copy-Item $LkPath -Destination swipl.exe
+$SwiplPath = Get-Command swipl.exe | Select-Object -ExpandProperty Definition
+Copy-Item $SwiplPath -Destination swipl.exe

--- a/scripts/prepareTestDirectory.ps1
+++ b/scripts/prepareTestDirectory.ps1
@@ -1,4 +1,3 @@
-Remove-Item -Recurse src\test-temp
 mkdir src\test-temp
 cd src\test-temp
 mkdir agents
@@ -6,18 +5,26 @@ mkdir languages
 mkdir languages\test-language
 cp -r ..\tests\test-language\build languages\test-language\build
 
-Remove-Item hc.exe
+if (Test-Path hc.exe) {
+  Remove-Item hc.exe
+}
 $HcPath = Get-Command hc.exe | Select-Object -ExpandProperty Definition
 Copy-Item $HcPath -Destination hc.exe
 
-Remove-Item holochain.exe
+if (Test-Path holochain.exe) {
+  Remove-Item holochain.exe
+}
 $HoloPath = Get-Command holochain.exe | Select-Object -ExpandProperty Definition
 Copy-Item $HoloPath -Destination holochain.exe
 
-Remove-Item lair-keystore.exe
+if (Test-Path lair-keystore.exe) {
+  Remove-Item lair-keystore.exe
+}
 $LkPath = Get-Command lair-keystore.exe | Select-Object -ExpandProperty Definition
 Copy-Item $LkPath -Destination lair-keystore.exe
 
-Remove-Item swipl.exe
+if (Test-Path swipl.exe) {
+  Remove-Item swipl.exe
+}
 $LkPath = Get-Command swipl.exe | Select-Object -ExpandProperty Definition
 Copy-Item $LkPath -Destination swipl.exe

--- a/scripts/prepareTestDirectory.ps1
+++ b/scripts/prepareTestDirectory.ps1
@@ -1,0 +1,23 @@
+Remove-Item -Recurse src\test-temp
+mkdir src\test-temp
+cd src\test-temp
+mkdir agents
+mkdir languages
+mkdir languages\test-language
+cp -r ..\tests\test-language\build languages\test-language\build
+
+Remove-Item hc.exe
+$HcPath = Get-Command hc.exe | Select-Object -ExpandProperty Definition
+Copy-Item $HcPath -Destination hc.exe
+
+Remove-Item holochain.exe
+$HoloPath = Get-Command holochain.exe | Select-Object -ExpandProperty Definition
+Copy-Item $HoloPath -Destination holochain.exe
+
+Remove-Item lair-keystore.exe
+$LkPath = Get-Command lair-keystore.exe | Select-Object -ExpandProperty Definition
+Copy-Item $LkPath -Destination lair-keystore.exe
+
+Remove-Item swipl.exe
+$LkPath = Get-Command swipl.exe | Select-Object -ExpandProperty Definition
+Copy-Item $LkPath -Destination swipl.exe

--- a/scripts/run-all-test.ps1
+++ b/scripts/run-all-test.ps1
@@ -1,0 +1,1 @@
+$env:PATH = '.\src\test-temp;'+ $env:PATH

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -6,7 +6,6 @@ import type LanguageController from "./LanguageController";
 import * as PubSub from './graphQL-interface/PubSub'
 import type PerspectiveContext from "./PerspectiveContext"
 import PrologInstance from "./PrologInstance";
-import { link } from "fs";
 
 export default class Perspective {
     name?: string;

--- a/src/core/PrologInstance.ts
+++ b/src/core/PrologInstance.ts
@@ -1,14 +1,16 @@
 import fs from "fs-extra";
+import path from "path";
 //@ts-ignore
 import swipl from 'swipl-stdio'
 //@ts-ignore
 import tmp from 'tmp'
+import { resourcePath } from "./Config";
 
 export default class PrologInstance {
     #engine
 
     constructor() {
-        this.#engine = new swipl.Engine()
+        this.#engine = new swipl.Engine(path.join(resourcePath, "swipl"))
     }
 
     async query(input: string) {

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -12,8 +12,6 @@ export async function isProcessRunning(processName: string): Promise<boolean> {
       require('child_process').exec(cmd, (err: Error, stdout: string, stderr: string) => {
         if (err) reject(err)
 
-        console.log('isProcessRunning', process.platform, stdout, err, stderr);
-  
         resolve(stdout.toLowerCase().indexOf(processName.toLowerCase()) > -1)
       })
     })

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -11,6 +11,8 @@ export async function isProcessRunning(processName: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
       require('child_process').exec(cmd, (err: Error, stdout: string, stderr: string) => {
         if (err) reject(err)
+
+        console.log('isProcessRunning', process.platform, stdout, err, stderr);
   
         resolve(stdout.toLowerCase().indexOf(processName.toLowerCase()) > -1)
       })


### PR DESCRIPTION
- Forked swipl package to be able to work with windows & also added support to use the passed swipl binary rather than using one in the $PATH. https://github.com/perspect3vism/node-swipl-stdio
- Tests are passing in windows.
- Added a new job for windows in CI.