### PR TITLE
Don't add `ad4m` to provided appDataPath. Use as rootConfigPath.

### DIFF
--- a/scripts/injectPublishingAgent.js
+++ b/scripts/injectPublishingAgent.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 
-const publishingAgentPath = "./src/test-temp/agents/p-agent/ad4m/agent.json";
+const publishingAgentPath = "./src/test-temp/agents/p-agent/agent.json";
 const bootstrapSeedPath = "./src/tests/bootstrapSeed.json";
 
 async function main() {

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -65,7 +65,7 @@ export interface CoreConfig {
 export function init(c: CoreConfig) {
     //Reinit vars
     resourcePath = c.appResourcePath;
-    rootConfigPath = path.join(c.appDataPath, 'ad4m')
+    rootConfigPath = c.appDataPath
     dataPath = path.join(rootConfigPath, 'data')
     languagesPath = path.join(rootConfigPath, 'languages')
     tempLangPath = path.join(languagesPath, "temp")

--- a/src/tests/runtime.ts
+++ b/src/tests/runtime.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 
 const PERSPECT3VISM_AGENT = "did:key:zQ3shkkuZLvqeFgHdgZgFMUx8VGkgVWsLA83w2oekhZxoCW2n"
 const DIFF_SYNC_OFFICIAL = fs.readFileSync("./scripts/perspective-diff-sync-hash").toString();
-const PUBLISHING_AGENT = JSON.parse(fs.readFileSync("./src/test-temp/agents/p-agent/ad4m/agent.json").toString())["did"];
+const PUBLISHING_AGENT = JSON.parse(fs.readFileSync("./src/test-temp/agents/p-agent/agent.json").toString())["did"];
 
 export default function runtimeTests(testContext: TestContext) {
     return () => {


### PR DESCRIPTION
...in order to have full control over the config/data directory path from ad4m-host.