### PR TITLE
Fix race condition when rebuilding prolog engine

### DIFF
--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -488,15 +488,16 @@ export default class Perspective {
         } 
 
         if(error) throw error
-        
-        this.#prologNeedsRebuild = false
         this.#prologEngine = prolog
     }
 
     async prologQuery(query: string): Promise<any> {
         await this.callLinksAdapter("pull");
-        if(!this.#prologEngine || this.#prologNeedsRebuild)
+        if(!this.#prologEngine || this.#prologNeedsRebuild) {
+            this.#prologNeedsRebuild = false
             await this.spawnPrologEngine()
+        }
+            
         
         return await this.#prologEngine!.query(query)
     }

--- a/src/tests/sdna/todo.pl
+++ b/src/tests/sdna/todo.pl
@@ -1,8 +1,10 @@
 register_sdna_flow("TODO", t).
 flowable(_, t).
-start_action(t, '[{action: "addLink", source: "this", predicate: "todo://state", target: "todo://ready"}').
+
 flow_state(ExprAddr, 0, t) :- triple(ExprAddr, "todo://state", "todo://ready").
-action(0, "Start", 0.5, '[{action: "addLink", source: "this", predicate: "todo://state", target: "todo://doing"}, {action: "removeLink", source: "this", predicate: "todo://state", target: "todo://ready"}]').
 flow_state(ExprAddr, 0.5, t) :- triple(ExprAddr, "todo://state", "todo://doing").
-action(0.5, "Finish", 1, '[{action: "addLink", source: "this", predicate: "todo://state", target: "todo://done"}, {action: "removeLink", source: "this", predicate: "todo://state", target: "todo://doing"}]').
 flow_state(ExprAddr, 1, t) :- triple(ExprAddr, "todo://state", "todo://done").
+
+start_action('[{action: "addLink", source: "this", predicate: "todo://state", target: "todo://ready"}]', t).
+action(0, "Start", 0.5, '[{action: "addLink", source: "this", predicate: "todo://state", target: "todo://doing"}, {action: "removeLink", source: "this", predicate: "todo://state", target: "todo://ready"}]').
+action(0.5, "Finish", 1, '[{action: "addLink", source: "this", predicate: "todo://state", target: "todo://done"}, {action: "removeLink", source: "this", predicate: "todo://state", target: "todo://doing"}]').


### PR DESCRIPTION
Changes to a perspective that happen quickly after another could cause the prolog engine to end up in an intermediate state (of the perspective link data) since spawning the engine takes a bit of time. Setting `prologNeedsRebuild` to false after the first new engine state was spawned means missing the second update.

This fixes it.