### PR TITLE
Extend the expiration date.

### DIFF
--- a/src/core/agent/Auth.ts
+++ b/src/core/agent/Auth.ts
@@ -359,7 +359,7 @@ export const checkCapability = (capabilities: Capabilities, expected: Capability
     }
 }
 
-export const DefaultTokenValidPeriod = 7 * 24 * 60 * 60; // 7 days in seconds
+export const DefaultTokenValidPeriod = 30 * 24 * 60 * 60; // 30 days in seconds
 
 export interface AuthInfoExtended {
     requestId: string,


### PR DESCRIPTION
Extends the token expiration date to be 30 days. 
We make want users to set this expiration date when making capability request.

Make it no expiration date still hold a lot of risk to data when jwt leaks.