### PR TITLE
Prolog Engine better performance and no race-condition

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 nix/*
 .github/*
+src/test-temp/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@transmute/did-wallet": "lucksus/did-wallet",
         "@types/json-stable-stringify": "^1.0.33",
         "apollo-server": "^2.18.2",
+        "async-mutex": "^0.3.2",
         "fs-extra": "^10.0.0",
         "get-port": "5.1.1",
         "graphql": "^15.3.0",
@@ -3401,6 +3402,19 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
+    "node_modules/async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -19037,6 +19051,21 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
+    "async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
     },
     "async-retry": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perspect3vism/ad4m-executor",
-  "version": "0.1.45-alpha-3",
+  "version": "0.1.45-alpha-4",
   "description": "Node.js package that allows the running/interfacing of AD4M Languages & Perspectives.",
   "main": "lib/main.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perspect3vism/ad4m-executor",
-  "version": "0.1.45-alpha-5",
+  "version": "0.1.44",
   "description": "Node.js package that allows the running/interfacing of AD4M Languages & Perspectives.",
   "main": "lib/main.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test-integration": "jest --forceExit src/tests/integration.test.ts",
     "test-all": "PATH=$PATH:./src/test-temp jest --forceExit",
     "test-all:windows": "powershell -ExecutionPolicy Bypass -File ./scripts/run-all-test.ps1 & jest --forceExit",
-    "test": "jest",
+    "test": "npm run prepare-test && nix-shell --run \"npm run test-all\" && node scripts/cleanTestingData.js",
     "test:windows": "npm run prepare-test:windows && npm run test-all:windows && node scripts/cleanTestingData.js",
     "jest": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@transmute/did-wallet": "lucksus/did-wallet",
     "@types/json-stable-stringify": "^1.0.33",
     "apollo-server": "^2.18.2",
+    "async-mutex": "^0.3.2",
     "fs-extra": "^10.0.0",
     "get-port": "5.1.1",
     "graphql": "^15.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perspect3vism/ad4m-executor",
-  "version": "0.1.44",
+  "version": "0.1.45-alpha-3",
   "description": "Node.js package that allows the running/interfacing of AD4M Languages & Perspectives.",
   "main": "lib/main.js",
   "files": [
@@ -25,7 +25,7 @@
     "test-integration": "jest --forceExit src/tests/integration.test.ts",
     "test-all": "PATH=$PATH:./src/test-temp jest --forceExit",
     "test-all:windows": "powershell -ExecutionPolicy Bypass -File ./scripts/run-all-test.ps1 & jest --forceExit",
-    "test": "npm run prepare-test && nix-shell --run \"npm run test-all\" && node scripts/cleanTestingData.js",
+    "test": "jest",
     "test:windows": "npm run prepare-test:windows && npm run test-all:windows && node scripts/cleanTestingData.js",
     "jest": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perspect3vism/ad4m-executor",
-  "version": "0.1.45-alpha-4",
+  "version": "0.1.45-alpha-5",
   "description": "Node.js package that allows the running/interfacing of AD4M Languages & Perspectives.",
   "main": "lib/main.js",
   "files": [

--- a/src/core/Perspective.test.ts
+++ b/src/core/Perspective.test.ts
@@ -118,7 +118,27 @@ describe('Perspective', () => {
             await perspective!.removeLink(link)
             const result = await perspective!.prologQuery("triple(X,Y,Z)");
             expect(result.length).toEqual(4)
+        })
+    })
 
+    describe('Prolog Engine', () => {
+        it('answers correctly in a run with multiple link additions/removals', async () => {
+            let result 
+            let l1 = await perspective!.addLink({source: 'ad4m://self', target: 'ad4m://test1'})
+
+            result = await perspective!.prologQuery("triple(Source,Pred,Target)")
+            expect(result.length).toEqual(1)
+            expect(result[0].Source).toBe('ad4m://self')
+            expect(result[0].Target).toBe('ad4m://test1')
+
+            let l2 = await perspective!.addLink({source: 'ad4m://self', target: 'ad4m://test2'})
+
+            result = await perspective!.prologQuery("triple(Source,Pred,Target)")
+            expect(result.length).toEqual(2)
+            expect(result[1].Source).toBe('ad4m://self')
+            expect(result[1].Target).toBe('ad4m://test2')
+
+            //...TBC
         })
     })
 

--- a/src/core/Perspective.test.ts
+++ b/src/core/Perspective.test.ts
@@ -36,7 +36,8 @@ const languageController = {
             return linksAdapter
         else
             return null
-    })
+    }),
+    languageByRef: jest.fn(ref => ref)
 }
 
 
@@ -61,9 +62,9 @@ describe('Perspective', () => {
         allLinks = []
     })
 
-    it('wraps links in expressions on addLink', () => {
+    it('wraps links in expressions on addLink', async () => {
         const link = createLink()
-        const expression = perspective!.addLink(link)
+        const expression = await perspective!.addLink(link)
         expect(expression.author).toEqual(agentService.agent.did)
         expect(expression.data).toEqual(link)
         expect(agentService.createSignedExpression.mock.calls.length).toBe(1)
@@ -71,15 +72,15 @@ describe('Perspective', () => {
     })
 
     describe('after adding 5 links', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             for(let i=0; i<5; i++) {
                 const link = createLink()
                 if(i%2 === 0) {
                     link.source = 'root'
                 }
                 //@ts-ignore
-                allLinks!.push(link)
-                perspective!.addLink(link)
+                allLinks!.push(await perspective!.addLink(link))
+                
             }
         })
 
@@ -95,7 +96,7 @@ describe('Perspective', () => {
             for(let i=0; i<5; i++) {
                 expect(result).toEqual(
                     expect.arrayContaining(
-                        [expect.objectContaining({data: allLinks![i]})]
+                        [expect.objectContaining(allLinks![i])]
                     )
                 )
             }
@@ -104,6 +105,20 @@ describe('Perspective', () => {
         it('can get links by source', async () => {
             const result = await perspective!.getLinks({source: 'root'} as LinkQuery)
             expect(result.length).toEqual(3)
+        })
+
+        it('Prolog queries return 5 triples', async () => {
+            const result = await perspective!.prologQuery("triple(X,Y,Z).")
+            expect(result.length).toEqual(5)
+        })
+
+        it('Prolog gets correctly updated when removing links', async () => {
+            const link = allLinks![0]
+            console.log("LINK TO REMOVE", link)
+            await perspective!.removeLink(link)
+            const result = await perspective!.prologQuery("triple(X,Y,Z)");
+            expect(result.length).toEqual(4)
+
         })
     })
 

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -540,9 +540,9 @@ export default class Perspective {
                 this.#prologNeedsRebuild = false
             }
             if(this.#prologNeedsRebuild) {
+                this.#prologNeedsRebuild = false
                 const facts = await this.initEngineFacts()
                 await this.#prologEngine!.consult(facts)
-                this.#prologNeedsRebuild = false
             }
         })
         

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -445,24 +445,39 @@ export default class Perspective {
     async addLinkToProlog(link: LinkExpression) {
         this.#prologNeedsRebuild = true
         return
-        if(this.isSDNALink(link)) {
-            this.#prologNeedsRebuild = true
-        } else {
-            let lines = [this.linkFact(link), ...await this.nodeFacts([link])]
-            await this.#prologEngine?.consult(lines.join('\n'))
-        }
+
+        // Leaving this dead code here to potentially get reactivated in the future.
+        // This doesn't work because consult/1 is more intelligent than I had expected,
+        // it first removes all old facts&rules to any predicate that it finds again when
+        // consulting. So we can just use consult/1 below in `prologQuery` to update the
+        // state with no problem.
+        // This is fine for now, but if our Prolog program becomes very large because of a
+        // large perspective, we might not want to always recreate the whole program file
+        // and instead use a different Prolog command to load our changes. Then we might
+        // want to surgically only alter the affected links like attempted here...
+        //
+        //
+        //if(this.isSDNALink(link)) {
+        //    this.#prologNeedsRebuild = true
+        //} else {
+        //    let lines = [this.linkFact(link), ...await this.nodeFacts([link])]
+        //    await this.#prologEngine?.consult(lines.join('\n'))
+        //}
     }
 
     async removeLinkFromProlog(link: LinkExpression) {
         this.#prologNeedsRebuild = true
         return
-        if(this.isSDNALink(link)) {
-            this.#prologNeedsRebuild = true
-        } else {
-            const fact = this.linkFact(link)
-            const factWithoutDot = fact.substring(0, fact.length-1)
-            await this.#prologEngine?.consult(`retract(${factWithoutDot}).`)
-        }
+
+        // See above.
+        //
+        //if(this.isSDNALink(link)) {
+        //    this.#prologNeedsRebuild = true
+        //} else {
+        //    const fact = this.linkFact(link)
+        //    const factWithoutDot = fact.substring(0, fact.length-1)
+        //    await this.#prologEngine?.consult(`retract(${factWithoutDot}).`)
+        //}
     }
 
     isSDNALink(link: LinkExpression): boolean {


### PR DESCRIPTION
1. No respawning of swipl process when changes are made to perspective - instead we just call `consult/1` again which is already intelligent enough to replace old facts and rules.
2. Use `Mutex` to ensure any changes to Prolog engine are synchronized to prevent ending up in a stale state when changes come in faster than updating of the engine takes.
3. More tests