### PR TITLE
Integrating Literal language for signed literal expressions

### DIFF
--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -832,7 +832,7 @@ export default class LanguageController {
         }
         let expr;
 
-        if(ref.language.address == "literal") {
+        if(ref.language.address == "literal" || ref.language.name == 'literal') {
             expr = Literal.fromUrl(`literal://${ref.expression}`).get()
         } else {
             const lang = this.languageForExpression(ref);

--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -1,6 +1,6 @@
 import { 
     Address, Expression, Language, LanguageContext, 
-    LinkSyncAdapter, InteractionCall, InteractionMeta, PublicSharing, ReadOnlyLanguage, LanguageMetaInternal, LanguageMetaInput, PerspectiveExpression, parseExprUrl, Perspective 
+    LinkSyncAdapter, InteractionCall, InteractionMeta, PublicSharing, ReadOnlyLanguage, LanguageMetaInternal, LanguageMetaInput, PerspectiveExpression, parseExprUrl, Perspective, Literal 
 } from '@perspect3vism/ad4m';
 import { ExpressionRef, LanguageRef, LanguageExpression, LanguageLanguageInput, ExceptionType, PerspectiveDiff } from '@perspect3vism/ad4m';
 import { ExceptionInfo } from '@perspect3vism/ad4m/lib/src/runtime/RuntimeResolver';
@@ -765,6 +765,10 @@ export default class LanguageController {
     }
 
     async expressionCreate(lang: LanguageRef, content: object): Promise<ExpressionRef> {
+        if(lang.address == "literal") {
+            const expr = (this.#context as LanguageContext).agent.createSignedExpression(content)
+            return parseExprUrl(Literal.from(expr).toUrl())
+        }
         const language = await this.languageByRef(lang)
         if (!language.expressionAdapter) {
             throw new Error("Language does not have an expressionAdapter")
@@ -826,26 +830,34 @@ export default class LanguageController {
             const fixtureLang = Config.bootstrapFixtures.languages!.find(f=>f.address===ref.expression)
             if(fixtureLang && fixtureLang.meta) return fixtureLang.meta
         }
-        const lang = this.languageForExpression(ref);
-        if (!lang.expressionAdapter) {
-            throw Error("Language does not have an expresionAdapter!")
-        };
-        const langIsImmutable = await this.isImmutableExpression(ref);
         let expr;
-        if (langIsImmutable) {
-            console.log("Calling cache for expression...");
-            const cachedExpression = this.#db.getExpression(ref.expression);
-            if (cachedExpression) {
-                console.log("Cache hit...");
-                expr = JSON.parse(cachedExpression) as Expression
-            } else {
-                console.log("Cache miss...");
-                expr = await lang.expressionAdapter.get(ref.expression);
-                if (expr) { this.#db.addExpression(ref.expression, JSON.stringify(expr)) };
-            };
+
+        if(ref.language.address == "literal") {
+            expr = Literal.fromUrl(`literal://${ref.expression}`).get()
         } else {
-            expr = await lang.expressionAdapter.get(ref.expression);
+            const lang = this.languageForExpression(ref);
+            if (!lang.expressionAdapter) {
+                throw Error("Language does not have an expresionAdapter!")
+            };
+            
+            const langIsImmutable = await this.isImmutableExpression(ref);
+            if (langIsImmutable) {
+                console.log("Calling cache for expression...");
+                const cachedExpression = this.#db.getExpression(ref.expression);
+                if (cachedExpression) {
+                    console.log("Cache hit...");
+                    expr = JSON.parse(cachedExpression) as Expression
+                } else {
+                    console.log("Cache miss...");
+                    expr = await lang.expressionAdapter.get(ref.expression);
+                    if (expr) { this.#db.addExpression(ref.expression, JSON.stringify(expr)) };
+                };
+            } else {
+                expr = await lang.expressionAdapter.get(ref.expression);
+            }
         }
+        
+
         if(expr) {
             try{
                 if(! await this.#signatures.verify(expr)) {
@@ -893,6 +905,7 @@ export default class LanguageController {
     }
 
     async isImmutableExpression(ref: ExpressionRef): Promise<boolean> {
+        if(ref.language.address == "literal") return true
         const language = await this.languageByRef(ref.language);
         if (!language.isImmutableExpression) {
             return false

--- a/src/core/Perspective.test.ts
+++ b/src/core/Perspective.test.ts
@@ -135,6 +135,8 @@ describe('Perspective', () => {
 
             result = await perspective!.prologQuery("triple(Source,Pred,Target)")
             expect(result.length).toEqual(2)
+            //@ts-ignore
+            result.sort((a,b) => a.Target < b.Target)
             expect(result[1].Source).toBe('ad4m://self')
             expect(result[1].Target).toBe('ad4m://test2')
 

--- a/src/core/graphQL-interface/GraphQL.ts
+++ b/src/core/graphQL-interface/GraphQL.ts
@@ -679,7 +679,14 @@ function createResolvers(core: PerspectivismCore, config: any) {
             //@ts-ignore
             language: async (expression) => {
                 //console.log("GQL LANGUAGE", expression)
-                const lang = await core.languageController.languageForExpression(expression.ref) as any
+                let lang
+                try {
+                    lang = await core.languageController.languageForExpression(expression.ref) as any    
+                } catch(e) {
+                    console.error("While trying to get language for expression", expression, ":", e)
+                    lang = {}
+                }
+                
                 lang.address = expression.ref.language.address
                 return lang
             },

--- a/src/tests/expression.ts
+++ b/src/tests/expression.ts
@@ -1,4 +1,4 @@
-import { InteractionCall, LanguageMetaInput } from '@perspect3vism/ad4m'
+import { InteractionCall, LanguageMetaInput, Literal, parseExprUrl } from '@perspect3vism/ad4m'
 import { TestContext } from './integration.test'
 import fs from "fs";
 
@@ -116,6 +116,23 @@ export default function expressionTests(testContext: TestContext) {
                 expect(expr).toBeDefined()
                 expect(expr.proof.valid).toBeTruthy()
                 expect(expr.data).toBe("\"modified note\"");
+            })
+
+            it('Literal language expressions can be created with signature and can get resolved from URL', async () => {
+                const ad4mClient = testContext.ad4mClient!
+
+                const TEST_DATA = "Hello World"
+                const addr = await ad4mClient.expression.create(TEST_DATA, "literal")
+                const exprRef = parseExprUrl(addr)
+                expect(exprRef.language.address).toBe("literal")
+
+                const expr = Literal.fromUrl(addr).get()
+
+                expect(expr.data).toBe(TEST_DATA)
+
+                const expr2 = await ad4mClient.expression.get(addr)
+
+                expect(expr2).toStrictEqual(expr)
             })
         })
     }

--- a/src/tests/expression.ts
+++ b/src/tests/expression.ts
@@ -127,10 +127,13 @@ export default function expressionTests(testContext: TestContext) {
                 expect(exprRef.language.address).toBe("literal")
 
                 const expr = Literal.fromUrl(addr).get()
+                delete expr.proof.invalid
 
                 expect(expr.data).toBe(TEST_DATA)
 
-                const expr2 = await ad4mClient.expression.get(addr)
+                const expr2Raw = await ad4mClient.expression.getRaw(addr)
+                const expr2 = JSON.parse(expr2Raw)
+                console.log(expr2)
 
                 expect(expr2).toStrictEqual(expr)
             })


### PR DESCRIPTION
* special case in `LanguageController.expressionCreate()`
* special case in `LanguageController.getExpression()`
* don't fail when trying to get language from expression
* tests