### PR TITLE
Various fixes

### DIFF
--- a/src/core/LanguageController.ts
+++ b/src/core/LanguageController.ts
@@ -284,7 +284,7 @@ export default class LanguageController {
             languageMeta = {data: {}};
         }
 
-        console.log("LanguageController: INSTALLING NEW LANGUAGE:", languageMeta.data)
+        console.log("LanguageController.installLanguage: INSTALLING LANGUAGE:", languageMeta.data)
         let bundlePath = path.join(path.join(this.#config.languagesPath, address), "bundle.js");
         let source;
         let hash;

--- a/src/core/Perspective.test.ts
+++ b/src/core/Perspective.test.ts
@@ -9,6 +9,7 @@ import { createLink } from '../testutils/links'
 import { createMockExpression } from '../testutils/expression'
 import { MainConfig } from './Config'
 import path from "path";
+import sleep from '../tests/sleep'
 
 
 const did = 'did:local-test-agent'
@@ -149,7 +150,6 @@ describe('Perspective', () => {
             expect(linkResult[0].Timestamp).not.toBeNaN();
 
             let l2 = await perspective!.addLink({source: 'ad4m://self', target: 'ad4m://test2'})
-
             result = await perspective!.prologQuery("triple(Source,Pred,Target)")
             expect(result.length).toEqual(2)
             linkResult = await perspective!.prologQuery("link(Source,Pred,Target,Timestamp,Author)")

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -9,6 +9,11 @@ import PrologInstance from "./PrologInstance";
 import { MainConfig } from "./Config";
 import { Mutex } from 'async-mutex'
 
+type PerspectiveSubscription = {
+    perspective: PerspectiveHandle,
+    link: LinkExpression
+}
+
 export default class Perspective {
     name?: string;
     uuid?: string;
@@ -41,7 +46,7 @@ export default class Perspective {
         this.#prologEngine = null
         this.#prologNeedsRebuild = true
 
-        this.#pubsub.subscribe(PubSub.LINK_ADDED_TOPIC, (perspective: PerspectiveHandle) => {
+        this.#pubsub.subscribe(PubSub.LINK_ADDED_TOPIC, ({ perspective }: PerspectiveSubscription) => {
             console.log("GOT LINKS SIGNAL", perspective, this.uuid);
             if (perspective.uuid === this.uuid) {
                 console.log("setting to rebuild prolog");
@@ -49,7 +54,7 @@ export default class Perspective {
             }
         })
 
-        this.#pubsub.subscribe(PubSub.LINK_REMOVED_TOPIC, (perspective: PerspectiveHandle) => {
+        this.#pubsub.subscribe(PubSub.LINK_REMOVED_TOPIC, ({ perspective }: PerspectiveSubscription) => {
             console.log("GOT LINKS REMOVED SIGNAL", perspective, this.uuid);
             if (perspective.uuid === this.uuid) {
                 console.log("removed setting to rebuild prolog");

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -47,17 +47,13 @@ export default class Perspective {
         this.#prologNeedsRebuild = true
 
         this.#pubsub.subscribe(PubSub.LINK_ADDED_TOPIC, ({ perspective }: PerspectiveSubscription) => {
-            console.log("GOT LINKS SIGNAL", perspective, this.uuid);
             if (perspective.uuid === this.uuid) {
-                console.log("setting to rebuild prolog");
                 this.#prologNeedsRebuild = true
             }
         })
 
         this.#pubsub.subscribe(PubSub.LINK_REMOVED_TOPIC, ({ perspective }: PerspectiveSubscription) => {
-            console.log("GOT LINKS REMOVED SIGNAL", perspective, this.uuid);
             if (perspective.uuid === this.uuid) {
-                console.log("removed setting to rebuild prolog");
                 this.#prologNeedsRebuild = true
             }
         })
@@ -253,6 +249,7 @@ export default class Perspective {
         } as PerspectiveDiff)
 
         this.addLocalLink(linkExpression)
+        this.#prologNeedsRebuild = true;
         this.#pubsub.publish(PubSub.LINK_ADDED_TOPIC, {
             perspective: this.plain(),
             link: linkExpression
@@ -297,6 +294,7 @@ export default class Perspective {
             removals: [oldLink]
         } as PerspectiveDiff)
         const perspective = this.plain();
+        this.#prologNeedsRebuild = true;
         this.#pubsub.publish(PubSub.LINK_REMOVED_TOPIC, {
             perspective: perspective,
             link: oldLink
@@ -314,7 +312,8 @@ export default class Perspective {
         this.callLinksAdapter('commit',  {
             additions: [],
             removals: [linkExpression]
-        } as PerspectiveDiff)
+        } as PerspectiveDiff);
+        this.#prologNeedsRebuild = true;
         this.#pubsub.publish(PubSub.LINK_REMOVED_TOPIC, {
             perspective: this.plain(),
             link: linkExpression

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -553,8 +553,12 @@ export default class Perspective {
         for(let linkExpression of allLinks) {
             let link = linkExpression.data
             if(this.isSDNALink(link)) {
-                let code = Literal.fromUrl(link.target).get()
-                lines.push(code)
+                try {
+                    let code = Literal.fromUrl(link.target).get()
+                    lines.push(code)
+                } catch {
+                    console.error("Perspective.initEngineFacts: Error loading SocialDNA link target as literal... Ignoring SocialDNA link.");
+                }
             }
         }
 

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -514,7 +514,7 @@ export default class Perspective {
     }
 
     isSDNALink(link: LinkExpression): boolean {
-        return link.source == 'self' && link.predicate == 'ad4m://has_zome'
+        return link.source == 'ad4m://self' && link.predicate == 'ad4m://has_zome'
     }
 
     async initEngineFacts(): Promise<string> {

--- a/src/core/PerspectivesController.ts
+++ b/src/core/PerspectivesController.ts
@@ -38,6 +38,7 @@ export default class PerspectivesController {
         this.#context.languageController!.addLinkObserver((diff: PerspectiveDiff, lang: LanguageRef) => {
             let perspective = Array.from(this.#perspectiveInstances.values()).find((perspective: Perspective) => perspective.neighbourhood?.linkLanguage === lang.address);
             if (perspective) {
+                console.log("PerspectiveController: received signal from linkObserver, adding remote links from a language to a local perspective...");
                 perspective.populateLocalLinks(diff.additions, diff.removals);
 
                 for (const link of diff.additions) {

--- a/src/core/storage-services/Holochain/HcExecution.ts
+++ b/src/core/storage-services/Holochain/HcExecution.ts
@@ -154,7 +154,7 @@ async function initializeLairKeystore(lairPath: string, hcDataPath: string, conf
             const conductorConfigPath = path.join(conductorPath!, "conductor-config.yaml");
             const holochainAppPort = appPort ? appPort : 1337;
             const holochainAdminPort = adminPort ? adminPort : 2000;
-            if(useMdns === undefined) useMdns = true
+            if(useMdns === undefined) useMdns = false
             if(useBootstrap === undefined) useBootstrap = true
             if(useProxy === undefined) useProxy = true
             if(useLocalProxy === undefined) useLocalProxy = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,12 +92,12 @@ export async function init(config: OuterConfig): Promise<PerspectivismCore> {
     } = config
     if(!gqlPort) gqlPort = 4000
     // Check to see if PORT 2000 & 1337 are available if not returns a random PORT
-    if(!hcPortAdmin) hcPortAdmin = await getPort({ port: 2000 });
-    if(!hcPortApp) hcPortApp = await getPort({ port: 1337 });
-    if(hcUseMdns === undefined) hcUseMdns = false
-    if(hcUseProxy === undefined) hcUseProxy = true
-    if(hcUseBootstrap === undefined) hcUseBootstrap = true
-    if(languageLanguageOnly === undefined) languageLanguageOnly = false;
+    if(!hcPortAdmin) config.hcPortAdmin = await getPort({ port: 2000 });
+    if(!hcPortApp) config.hcPortApp = await getPort({ port: 1337 });
+    if(hcUseMdns === undefined) config.hcUseMdns = false
+    if(hcUseProxy === undefined) config.hcUseProxy = true
+    if(hcUseBootstrap === undefined) config.hcUseBootstrap = true
+    if(languageLanguageOnly === undefined) config.languageLanguageOnly = false;
 
     if(!fs.existsSync(networkBootstrapSeed)) {
       throw new Error(`Could not find networkBootstrapSeed at path ${networkBootstrapSeed}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,20 +84,16 @@ export interface SeedFileSchema {
 export async function init(config: OuterConfig): Promise<PerspectivismCore> {
     let { 
       resourcePath, appDataPath, networkBootstrapSeed, appLangAliases, bootstrapFixtures, languageLanguageOnly,
-      mocks, gqlPort, 
-      hcPortAdmin, hcPortApp,
-      ipfsSwarmPort, ipfsRepoPath,
-      hcUseLocalProxy, hcUseMdns, hcUseProxy, hcUseBootstrap, connectHolochain, reqCredential,
-      swiplPath, swiplHomePath
+      mocks, gqlPort, ipfsSwarmPort, ipfsRepoPath, reqCredential, swiplPath, swiplHomePath
     } = config
     if(!gqlPort) gqlPort = 4000
     // Check to see if PORT 2000 & 1337 are available if not returns a random PORT
-    if(!hcPortAdmin) config.hcPortAdmin = await getPort({ port: 2000 });
-    if(!hcPortApp) config.hcPortApp = await getPort({ port: 1337 });
-    if(hcUseMdns === undefined) config.hcUseMdns = false
-    if(hcUseProxy === undefined) config.hcUseProxy = true
-    if(hcUseBootstrap === undefined) config.hcUseBootstrap = true
-    if(languageLanguageOnly === undefined) config.languageLanguageOnly = false;
+    if(!config.hcPortAdmin) config.hcPortAdmin = await getPort({ port: 2000 });
+    if(!config.hcPortApp) config.hcPortApp = await getPort({ port: 1337 });
+    if(config.hcUseMdns === undefined) config.hcUseMdns = false
+    if(config.hcUseProxy === undefined) config.hcUseProxy = true
+    if(config.hcUseBootstrap === undefined) config.hcUseBootstrap = true
+    if(config.languageLanguageOnly === undefined) config.languageLanguageOnly = false;
 
     if(!fs.existsSync(networkBootstrapSeed)) {
       throw new Error(`Could not find networkBootstrapSeed at path ${networkBootstrapSeed}`)

--- a/src/tests/social-dna-flow.ts
+++ b/src/tests/social-dna-flow.ts
@@ -36,17 +36,17 @@ export default function socialDNATests(testContext: TestContext) {
                 expect(perspective.name).toEqual("sdna-test");
             
                 await perspective.add(new Link({
-                    source: 'self', 
+                    source: 'ad4m://self', 
                     predicate: 'ad4m://has_zome',
                     target: Literal.from(sdna.join('\n')).toUrl(),
                 }))
 
-                let sDNAFacts = await ad4mClient!.perspective.queryLinks(perspective.uuid, new LinkQuery({source: "self", predicate: "ad4m://has_zome"}));
+                let sDNAFacts = await ad4mClient!.perspective.queryLinks(perspective.uuid, new LinkQuery({source: "ad4m://self", predicate: "ad4m://has_zome"}));
                 expect(sDNAFacts.length).toEqual(1);
                 let flows = await perspective.sdnaFlows()
                 expect(flows[0]).toBe('TODO')
 
-                await perspective.add(new Link({source: 'self', target: 'test-lang://1234'}))
+                await perspective.add(new Link({source: 'ad4m://self', target: 'test-lang://1234'}))
                 let availableFlows = await perspective.availableFlows('test-lang://1234')
                 expect(availableFlows.length).toEqual(1)
                 expect(availableFlows[0]).toEqual('TODO')


### PR DESCRIPTION
- SocialDNA now loads from links with source: `ad4m://self`
- fix `OuterConfig` mutation in `init()`
- fix default for useMdns on conductor writing on lair-keystore close
- try/catch loading SocialDNA
- fix prolog rebuild on link signals
- fix prolog rebuild on pulls