### PR TITLE
make `addLink()` async and await correctly

### DIFF
--- a/src/core/graphQL-interface/GraphQL.ts
+++ b/src/core/graphQL-interface/GraphQL.ts
@@ -487,11 +487,11 @@ function createResolvers(core: PerspectivismCore, config: OuterConfig) {
                 return core.perspectivesController.add(name)
             },
             //@ts-ignore
-            perspectiveAddLink: (parent, args, context, info) => {
+            perspectiveAddLink: async (parent, args, context, info) => {
                 const { uuid, link } = args
                 checkCapability(context.capabilities, Auth.perspectiveUpdateCapability([uuid]))
                 const perspective = core.perspectivesController.perspective(uuid)
-                return perspective.addLink(link)
+                return await perspective.addLink(link)
             },
             //@ts-ignore
             perspectiveRemove: (parent, args, context, info) => {


### PR DESCRIPTION
not having this was causing ad4min to crash with:

```
[2022-08-26T18:07:40.641277709+01:00] INFO - [31m 2022-08-26T17:07:40.641Z HolochainService calling zome function: perspective-diff-sync perspective_diff_sync pull null 
[2022-08-26T18:07:40.641358398+01:00] INFO - For language with address QmZhzAeRVSE6Bg4PEHKHCqExPR6ZSPy1bPTCywXzqA5tpm [0m
[2022-08-26T18:08:25.190764330+01:00] ERROR - /snapshot/ad4m-host/node_modules/@perspect3vism/ad4m-executor/lib/core/Perspective.js:173
[2022-08-26T18:08:25.190889259+01:00] ERROR -             setTimeout(() => reject(Error("LinkLanguage took to long to respond, timeout at 20000ms")), 20000);
[2022-08-26T18:08:25.190934589+01:00] ERROR -                                     ^
[2022-08-26T18:08:25.190976969+01:00] ERROR - 
[2022-08-26T18:08:25.191018548+01:00] ERROR - Error: LinkLanguage took to long to respond, timeout at 20000ms
[2022-08-26T18:08:25.191059898+01:00] ERROR -     at Timeout._onTimeout (/snapshot/ad4m-host/node_modules/@perspect3vism/ad4m-executor/lib/core/Perspective.js:173:37)
[2022-08-26T18:08:25.191100988+01:00] ERROR -     at listOnTimeout (node:internal/timers:559:17)
[2022-08-26T18:08:25.191136727+01:00] ERROR -     at processTimers (node:internal/timers:502:7)
```

This is the same issue that we saw in: #84 
