### PR TITLE
Updated swipl to check windows snapshot directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "sha256": "^0.2.0",
     "sha3": "^2.1.3",
     "subscriptions-transport-ws": "^0.11.0",
-    "swipl-stdio": "perspect3vism/node-swipl-stdio.git#9d82de7fb3301f4ead2077aa7636d34159d93631",
+    "swipl-stdio": "perspect3vism/node-swipl-stdio.git#7094a055a4ec3511530140ca7a4447d6649a9dee",
     "tmp": "^0.2.1"
   }
 }


### PR DESCRIPTION
On Windows snapshot path starts `C:\\snapshot` .