### PR TITLE
add method for getting if agent is locked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@graphql-tools/schema": "^8.5.1",
         "@holochain/client": "0.3.2",
-        "@perspect3vism/ad4m": "0.1.34",
+        "@perspect3vism/ad4m": "0.1.35",
         "@transmute/did-key-ed25519": "^0.2.1-unstable.29",
         "@transmute/did-key-secp256k1": "^0.2.1-unstable.29",
         "@transmute/did-key.js": "^0.2.1-unstable.29",
@@ -1790,9 +1790,9 @@
       }
     },
     "node_modules/@perspect3vism/ad4m": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/@perspect3vism/ad4m/-/ad4m-0.1.34.tgz",
-      "integrity": "sha512-7+0iy3ZASoQ9dPBfQ6iz0oXuS2jESu2igTwtWgwVq3x3CcNEP5h97HiqAMiR0O3K+tAPT3+lZ80ZccyIkWDK6g==",
+      "version": "0.1.35",
+      "resolved": "https://registry.npmjs.org/@perspect3vism/ad4m/-/ad4m-0.1.35.tgz",
+      "integrity": "sha512-hFhaOeSwPkiQRzbIuHR8ke4YDb/jN1qknBnNC7W4fOhb4z5Le7yBW+GgGlXblxxNnoZ6zUv5JV8oquqSWYYaTQ==",
       "dependencies": {
         "@apollo/client": "3.6.9",
         "@holochain/client": "0.3.2",
@@ -15781,9 +15781,9 @@
       }
     },
     "@perspect3vism/ad4m": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/@perspect3vism/ad4m/-/ad4m-0.1.34.tgz",
-      "integrity": "sha512-7+0iy3ZASoQ9dPBfQ6iz0oXuS2jESu2igTwtWgwVq3x3CcNEP5h97HiqAMiR0O3K+tAPT3+lZ80ZccyIkWDK6g==",
+      "version": "0.1.35",
+      "resolved": "https://registry.npmjs.org/@perspect3vism/ad4m/-/ad4m-0.1.35.tgz",
+      "integrity": "sha512-hFhaOeSwPkiQRzbIuHR8ke4YDb/jN1qknBnNC7W4fOhb4z5Le7yBW+GgGlXblxxNnoZ6zUv5JV8oquqSWYYaTQ==",
       "requires": {
         "@apollo/client": "3.6.9",
         "@holochain/client": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@graphql-tools/schema": "^8.5.1",
     "@holochain/client": "0.3.2",
-    "@perspect3vism/ad4m": "0.1.34",
+    "@perspect3vism/ad4m": "0.1.35",
     "@transmute/did-key-ed25519": "^0.2.1-unstable.29",
     "@transmute/did-key-secp256k1": "^0.2.1-unstable.29",
     "@transmute/did-key.js": "^0.2.1-unstable.29",

--- a/src/core/graphQL-interface/GraphQL.ts
+++ b/src/core/graphQL-interface/GraphQL.ts
@@ -50,6 +50,10 @@ function createResolvers(core: PerspectivismCore, config: OuterConfig) {
                 return core.agentService.dump()
             },
             //@ts-ignore
+            agentIsLocked: (parent, args, context, info) => {
+                return !core.agentService.isUnlocked
+            },
+            //@ts-ignore
             expression: async (parent, args, context, info) => {
                 checkCapability(context.capabilities, Auth.EXPRESSION_READ_CAPABILITY)
                 const url = args.url.toString();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,10 +1076,10 @@
     "tslib" "^2.4.0"
     "webcrypto-core" "^1.7.4"
 
-"@perspect3vism/ad4m@0.1.34":
-  "integrity" "sha512-7+0iy3ZASoQ9dPBfQ6iz0oXuS2jESu2igTwtWgwVq3x3CcNEP5h97HiqAMiR0O3K+tAPT3+lZ80ZccyIkWDK6g=="
-  "resolved" "https://registry.npmjs.org/@perspect3vism/ad4m/-/ad4m-0.1.34.tgz"
-  "version" "0.1.34"
+"@perspect3vism/ad4m@0.1.35":
+  "integrity" "sha512-hFhaOeSwPkiQRzbIuHR8ke4YDb/jN1qknBnNC7W4fOhb4z5Le7yBW+GgGlXblxxNnoZ6zUv5JV8oquqSWYYaTQ=="
+  "resolved" "https://registry.npmjs.org/@perspect3vism/ad4m/-/ad4m-0.1.35.tgz"
+  "version" "0.1.35"
   dependencies:
     "@apollo/client" "3.6.9"
     "@holochain/client" "0.3.2"


### PR DESCRIPTION
This endpoint gives us a method of determining if an ad4m agent is locked without having to provide capability tokens. This is useful in ad4m-connect where we need to check if an agent is unlocked before we have passed through the capability token generation step.

Depends on https://github.com/perspect3vism/ad4m/pull/47 to be merged and release.
