### PR TITLE
Intelligent link language pull

### DIFF
--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -76,15 +76,19 @@ export default class Perspective {
         });
 
         // setup polling loop for Perspectives with a linkLanguage
-        this.getCurrentRevision().then(revision => {
-            // if revision is null, then we are not connected to the network yet, so we need to poll fast
-            if(!revision && this.createdFromJoin) {
-                this.isFastPolling = true;
-                this.#pollingInterval = this.setupPolling(5000);
-            } else {
-                this.#pollingInterval = this.setupPolling(30000);
-            }
-        })
+        try {
+            this.getCurrentRevision().then(revision => {
+                // if revision is null, then we are not connected to the network yet, so we need to poll fast
+                if(!revision && this.createdFromJoin) {
+                    this.isFastPolling = true;
+                    this.#pollingInterval = this.setupPolling(5000);
+                } else {
+                    this.#pollingInterval = this.setupPolling(30000);
+                }
+            })
+        } catch (e) {
+            console.error("Perspective.constructor(): Got error when trying to get current revision and setting polling loop", e);
+        }
 
         this.#prologMutex = new Mutex()
     }

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -21,6 +21,7 @@ export default class Perspective {
     timestamp?: string;
     neighbourhood?: Neighbourhood;
     sharedUrl?: string;
+    createdFromJoin: boolean;
 
     #db: any;
     #agent: AgentService;
@@ -33,9 +34,16 @@ export default class Perspective {
     #pollingInterval: any;
     #prologMutex: Mutex
 
-    constructor(id: PerspectiveHandle, context: PerspectiveContext, neighbourhood?: Neighbourhood) {
+    constructor(id: PerspectiveHandle, context: PerspectiveContext, neighbourhood?: Neighbourhood, createdFromJoin?: boolean) {
         this.updateFromId(id)
-        if (neighbourhood) this.neighbourhood = neighbourhood;
+        this.createdFromJoin = false;
+
+        if (neighbourhood) {
+            this.neighbourhood = neighbourhood
+            if (createdFromJoin) {
+                this.createdFromJoin = createdFromJoin;
+            };
+        };
 
         this.#db = context.db
         this.#agent = context.agentService!

--- a/src/core/Perspective.ts
+++ b/src/core/Perspective.ts
@@ -78,11 +78,11 @@ export default class Perspective {
         // setup polling loop for Perspectives with a linkLanguage
         this.getCurrentRevision().then(revision => {
             // if revision is null, then we are not connected to the network yet, so we need to poll fast
-            if(revision) {
-                this.#pollingInterval = this.setupPolling(30000);
-            } else {
+            if(!revision && this.createdFromJoin) {
                 this.isFastPolling = true;
                 this.#pollingInterval = this.setupPolling(5000);
+            } else {
+                this.#pollingInterval = this.setupPolling(30000);
             }
         })
 

--- a/src/core/PerspectivismCore.ts
+++ b/src/core/PerspectivismCore.ts
@@ -235,7 +235,7 @@ export default class PerspectivismCore {
         //Add shared perspective to original perpspective and then update controller
         perspectiveID.sharedUrl = neighbourhoodUrl
         perspectiveID.neighbourhood = neighbourhood;
-        this.#perspectivesController!.replace(perspectiveID, neighbourhood)
+        this.#perspectivesController!.replace(perspectiveID, neighbourhood, false)
         return neighbourhoodUrl
     }
 

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -1,7 +1,7 @@
 import low from 'lowdb'
 import FileSync from 'lowdb/adapters/FileSync'
 import path from 'path'
-import type { Expression, LinkExpression } from "@perspect3vism/ad4m";  
+import type { PerspectiveDiff } from "@perspect3vism/ad4m";  
 
 export class PerspectivismDb {
     #db: any
@@ -25,6 +25,10 @@ export class PerspectivismDb {
 
     targetKey(pUUID: string, target: string) {
         return `${pUUID}-to_target-${target}`
+    }
+
+    pendingLinkKey(pUUID: string) {
+        return `${pUUID}-pending_links`
     }
 
     storeLink(pUUID: string, link: object, linkName: string): void {
@@ -121,7 +125,6 @@ export class PerspectivismDb {
         this.remove(key, linkName)
     }
 
-
     remove(key: string, linkName: string): void {
         //@ts-ignore
         this.#db.get(key).remove(l => l===linkName).write()
@@ -132,6 +135,22 @@ export class PerspectivismDb {
     }
 
     getExpression(key: string): string | undefined {
+        return this.#db.get(key).value()
+    }
+
+    addPendingDiff(pUUID: string, diff: PerspectiveDiff): void {
+        const key = this.pendingLinkKey(pUUID);
+        if(!this.#db.has(key).value()) {
+            this.#db.set(key, []).write()
+        }
+
+        this.#db.get(key)
+            .push(diff)
+            .write()
+    }
+
+    getPendingDiffs(pUUID: string): PerspectiveDiff[] {
+        const key = this.pendingLinkKey(pUUID);
         return this.#db.get(key).value()
     }
 }

--- a/src/core/graphQL-interface/GraphQL.ts
+++ b/src/core/graphQL-interface/GraphQL.ts
@@ -33,15 +33,19 @@ function createResolvers(core: PerspectivismCore, config: OuterConfig) {
             agentByDID: async (parent, args, context, info) => {
                 checkCapability(context.capabilities, Auth.AGENT_READ_CAPABILITY)
                 const { did } = args;
-                const agentLanguage = core.languageController.getAgentLanguage().expressionAdapter;
-                if (!agentLanguage) {
-                    throw Error("Agent language does not have an expression adapter")
-                }
-                const expr = await agentLanguage.get(did);
-                if (expr != null) {
-                    return expr.data;
+                if (did != core.agentService.did) {
+                    const agentLanguage = core.languageController.getAgentLanguage().expressionAdapter;
+                    if (!agentLanguage) {
+                        throw Error("Agent language does not have an expression adapter")
+                    }
+                    const expr = await agentLanguage.get(did);
+                    if (expr != null) {
+                        return expr.data;
+                    } else {
+                        return null
+                    }
                 } else {
-                    return null
+                    return core.agentService.agent
                 }
             },
             //@ts-ignore

--- a/src/tests/neighbourhood.ts
+++ b/src/tests/neighbourhood.ts
@@ -68,6 +68,8 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
 
+                await sleep(5000)
+
                 let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
                 let tries = 1
 


### PR DESCRIPTION
This PR ensures that after joining a neighbourhood, we do not commit any entries to a link language until we have seen something ourselves, so long as the neighbourhood as one we joined and not created. 

With the holochain implementation of the link language, this has the benefit of enabling pull to use snapshots to fetch vs pulling on the raw graph. This is because the snapshot fetching code will only get triggered when currentRevision is null.

Additionally the first commit made to a link language will be batched into one diff mutation, reducing the number of commit entries made into the link language. 