### PR TITLE
feat: Rust-side model query endpoint (SPARQL filtering moved to Rust)

### DIFF
--- a/core/src/model/Ad4mModel.test.ts
+++ b/core/src/model/Ad4mModel.test.ts
@@ -631,9 +631,10 @@ describe("Ad4mModel.instancesFromQueryResult() and SPARQL integration", () => {
     ingredients: string[] = [];
   }
 
-  // Mock perspective with both querySparql and infer methods
+  // Mock perspective with querySparql, modelQuery, and infer methods
   const mockPerspective = {
     querySparql: jest.fn(),
+    modelQuery: jest.fn(),
     infer: jest.fn(),
     uuid: 'test-perspective-uuid',
     stringOrTemplateObjectToSubjectClassName: jest.fn().mockResolvedValue('Recipe')
@@ -770,18 +771,17 @@ describe("Ad4mModel.instancesFromQueryResult() and SPARQL integration", () => {
   });
 
   it("should use SPARQL when engine is 'sparql' in findAll()", async () => {
-    // Raw SPARQL rows (flat) — groupSPARQLResults will group them
-    const queryResults = [
-      { source: "literal:recipe1", predicate: "recipe://name", target: "Pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://ingredient", target: "pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-    ];
-
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+    // modelQuery returns already-hydrated instances from the Rust executor
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [
+        { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
+      ],
+      totalCount: 1
+    });
 
     const results = await Recipe.findAll(mockPerspective, {}, 'sparql');
 
-    expect(mockPerspective.querySparql).toHaveBeenCalledTimes(1);
+    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
     expect(mockPerspective.infer).not.toHaveBeenCalled();
     expect(results).toHaveLength(1);
     expect(results[0].name).toBe("Pasta");
@@ -805,38 +805,32 @@ describe("Ad4mModel.instancesFromQueryResult() and SPARQL integration", () => {
   });
 
   it("should use SPARQL when engine is 'sparql' in findAllAndCount()", async () => {
-    const queryResults = [
-      { source: "literal:recipe1", predicate: "recipe://name", target: "Pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://ingredient", target: "pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-    ];
-
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [
+        { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
+      ],
+      totalCount: 1
+    });
 
     const { results, totalCount } = await Recipe.findAllAndCount(mockPerspective, {}, 'sparql');
 
-    expect(mockPerspective.querySparql).toHaveBeenCalledTimes(1);
+    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
     expect(mockPerspective.infer).not.toHaveBeenCalled();
     expect(results).toHaveLength(1);
     expect(totalCount).toBe(1);
   });
 
   it("should use SPARQL when engine is 'sparql' in paginate()", async () => {
-    const queryResults = [
-      { source: "literal:recipe1", predicate: "recipe://name", target: "Pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://ingredient", target: "pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-    ];
-
-    // First call returns data, second call returns count (for SPARQL-paginated totalCount)
-    mockPerspective.querySparql
-      .mockResolvedValueOnce(queryResults)
-      .mockResolvedValueOnce([{ count: 1 }]);
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [
+        { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
+      ],
+      totalCount: 1
+    });
 
     const page = await Recipe.paginate(mockPerspective, 10, 1, {}, 'sparql');
 
-    // paginate now issues 2 SPARQL queries: data + count
-    expect(mockPerspective.querySparql).toHaveBeenCalledTimes(2);
+    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
     expect(mockPerspective.infer).not.toHaveBeenCalled();
     expect(page.results).toHaveLength(1);
     expect(page.pageSize).toBe(10);
@@ -845,12 +839,14 @@ describe("Ad4mModel.instancesFromQueryResult() and SPARQL integration", () => {
   });
 
   it("should use SPARQL when engine is 'sparql' in count()", async () => {
-    // count() now uses an efficient COUNT query that returns [{ count: N }]
-    mockPerspective.querySparql.mockResolvedValue([{ count: 5 }]);
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 5
+    });
 
     const count = await Recipe.count(mockPerspective, {}, 'sparql');
 
-    expect(mockPerspective.querySparql).toHaveBeenCalledTimes(1);
+    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
     expect(mockPerspective.infer).not.toHaveBeenCalled();
     expect(count).toBe(5);
   });
@@ -867,20 +863,19 @@ describe("Ad4mModel.instancesFromQueryResult() and SPARQL integration", () => {
   });
 
   it("should use SPARQL when engine is 'sparql' in ModelQueryBuilder.get()", async () => {
-    const queryResults = [
-      { source: "literal:recipe1", predicate: "recipe://name", target: "Pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://ingredient", target: "pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-    ];
-
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [
+        { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
+      ],
+      totalCount: 1
+    });
 
     const results = await Recipe.query(mockPerspective)
       .where({ name: "Pasta" })
       .engine('sparql')
       .get();
 
-    expect(mockPerspective.querySparql).toHaveBeenCalledTimes(1);
+    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
     expect(mockPerspective.infer).not.toHaveBeenCalled();
     expect(results).toHaveLength(1);
     expect(results[0].name).toBe("Pasta");
@@ -907,40 +902,35 @@ describe("Ad4mModel.instancesFromQueryResult() and SPARQL integration", () => {
   });
 
   it("should use SPARQL when engine is 'sparql' in ModelQueryBuilder.count()", async () => {
-    // count() counts the number of rows returned by the query (one row per source)
-    const queryResults = [
-      ...Array.from({ length: 3 }, (_, i) => [
-        { source: `literal:recipe${i+1}`, predicate: "recipe://name", target: `Recipe ${i+1}`, author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-        { source: `literal:recipe${i+1}`, predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-      ]).flat()
-    ];
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 3
+    });
 
     const count = await Recipe.query(mockPerspective)
       .where({ rating: { gt: 4 } })
       .engine('sparql')
       .count();
 
-    expect(mockPerspective.querySparql).toHaveBeenCalledTimes(1);
+    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
     expect(mockPerspective.infer).not.toHaveBeenCalled();
     expect(count).toBe(3);
   });
 
   it("should use SPARQL when engine is 'sparql' in ModelQueryBuilder.paginate()", async () => {
-    const queryResults = [
-      { source: "literal:recipe1", predicate: "recipe://name", target: "Pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-      { source: "literal:recipe1", predicate: "recipe://ingredient", target: "pasta", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-    ];
-
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [
+        { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
+      ],
+      totalCount: 1
+    });
 
     const page = await Recipe.query(mockPerspective)
       .where({ rating: { gt: 3 } })
       .engine('sparql')
       .paginate(10, 1);
 
-    expect(mockPerspective.querySparql).toHaveBeenCalledTimes(1);
+    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
     expect(mockPerspective.infer).not.toHaveBeenCalled();
     expect(page.results).toHaveLength(1);
     expect(page.pageSize).toBe(10);
@@ -965,6 +955,7 @@ describe("Ad4mModel.count() with advanced where conditions", () => {
   // Mock perspective
   const mockPerspective = {
     querySparql: jest.fn(),
+    modelQuery: jest.fn(),
     infer: jest.fn(),
     uuid: 'test-perspective-uuid',
     stringOrTemplateObjectToSubjectClassName: jest.fn().mockResolvedValue('Recipe')
@@ -974,132 +965,80 @@ describe("Ad4mModel.count() with advanced where conditions", () => {
     jest.clearAllMocks();
   });
 
-  it("should apply JS-level filtering for gt operator on properties in SPARQL count()", async () => {
-    // Mock query results: 5 recipes with ratings 1, 2, 3, 4, 5
-    const queryResults = [
-      ...Array.from({ length: 5 }, (_, i) => [
-        { source: `literal:recipe${i+1}`, predicate: "recipe://name", target: `Recipe ${i+1}`, author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-        { source: `literal:recipe${i+1}`, predicate: "recipe://rating", target: `${i+1}`, author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-      ]).flat()
-    ];
-    
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+  it("should apply filtering for gt operator on properties in SPARQL count()", async () => {
+    // With the new modelQuery endpoint, filtering happens server-side in Rust
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 2
+    });
 
     // Count recipes with rating > 3 (should match 2 recipes: rating 4 and 5)
     const count = await Recipe.count(mockPerspective, { where: { rating: { gt: 3 } } }, 'sparql');
     
-    // Verify count matches the number of instances that would be returned by findAll
-    const findAllResults = await Recipe.findAll(mockPerspective, { where: { rating: { gt: 3 } } }, 'sparql');
-    
     expect(count).toBe(2);
-    expect(count).toBe(findAllResults.length);
+    expect(mockPerspective.modelQuery).toHaveBeenCalled();
   });
 
-  it("should apply JS-level filtering for between operator on properties in SPARQL count()", async () => {
-    // Mock query results: 5 recipes with ratings 1, 2, 3, 4, 5
-    const queryResults = [
-      ...Array.from({ length: 5 }, (_, i) => [
-        { source: `literal:recipe${i+1}`, predicate: "recipe://name", target: `Recipe ${i+1}`, author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-        { source: `literal:recipe${i+1}`, predicate: "recipe://rating", target: `${i+1}`, author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-      ]).flat()
-    ];
-    
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+  it("should apply filtering for between operator on properties in SPARQL count()", async () => {
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 3
+    });
 
     // Count recipes with rating between 2 and 4 (should match 3 recipes: rating 2, 3, 4)
     const count = await Recipe.count(mockPerspective, { where: { rating: { between: [2, 4] } } }, 'sparql');
     
-    // Verify count matches the number of instances that would be returned by findAll
-    const findAllResults = await Recipe.findAll(mockPerspective, { where: { rating: { between: [2, 4] } } }, 'sparql');
-    
     expect(count).toBe(3);
-    expect(count).toBe(findAllResults.length);
+    expect(mockPerspective.modelQuery).toHaveBeenCalled();
   });
 
-  it("should apply JS-level filtering for timestamp gt operator in SPARQL count()", async () => {
-    // Mock query results: 5 recipes with different timestamps
-    const queryResults = [
-      ...Array.from({ length: 5 }, (_, i) => [
-        { source: `literal:recipe${i+1}`, predicate: "recipe://name", target: `Recipe ${i+1}`, author: "did:key:alice", timestamp: `2023-01-0${i+1}T00:00:00Z` },
-        { source: `literal:recipe${i+1}`, predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: `2023-01-0${i+1}T00:00:00Z` }
-      ]).flat()
-    ];
-    
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+  it("should apply filtering for timestamp gt operator in SPARQL count()", async () => {
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 2
+    });
 
-    // Count recipes with timestamp > 2023-01-03 (should match 2 recipes: 2023-01-04 and 2023-01-05)
     const targetTimestamp = new Date("2023-01-03T00:00:00Z").getTime();
     const count = await Recipe.count(mockPerspective, { where: { timestamp: { gt: targetTimestamp } } }, 'sparql');
     
-    // Verify count matches the number of instances that would be returned by findAll
-    const findAllResults = await Recipe.findAll(mockPerspective, { where: { timestamp: { gt: targetTimestamp } } }, 'sparql');
-    
     expect(count).toBe(2);
-    expect(count).toBe(findAllResults.length);
+    expect(mockPerspective.modelQuery).toHaveBeenCalled();
   });
 
-  it("should apply JS-level filtering for timestamp between operator in SPARQL count()", async () => {
-    // Mock query results: 5 recipes with different timestamps
-    const queryResults = [
-      ...Array.from({ length: 5 }, (_, i) => [
-        { source: `literal:recipe${i+1}`, predicate: "recipe://name", target: `Recipe ${i+1}`, author: "did:key:alice", timestamp: `2023-01-0${i+1}T00:00:00Z` },
-        { source: `literal:recipe${i+1}`, predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: `2023-01-0${i+1}T00:00:00Z` }
-      ]).flat()
-    ];
-    
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+  it("should apply filtering for timestamp between operator in SPARQL count()", async () => {
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 3
+    });
 
-    // Count recipes with timestamp between 2023-01-02 and 2023-01-04
     const startTimestamp = new Date("2023-01-02T00:00:00Z").getTime();
     const endTimestamp = new Date("2023-01-04T00:00:00Z").getTime();
     const count = await Recipe.count(mockPerspective, { 
       where: { timestamp: { between: [startTimestamp, endTimestamp] } } 
     }, 'sparql');
     
-    // Verify count matches the number of instances that would be returned by findAll
-    const findAllResults = await Recipe.findAll(mockPerspective, { 
-      where: { timestamp: { between: [startTimestamp, endTimestamp] } } 
-    }, 'sparql');
-    
     expect(count).toBe(3);
-    expect(count).toBe(findAllResults.length);
+    expect(mockPerspective.modelQuery).toHaveBeenCalled();
   });
 
-  it("should apply JS-level filtering for author filtering in SPARQL count()", async () => {
-    // Mock query results: 3 recipes by Alice and 2 by Bob
-    const queryResults = [
-      ...Array.from({ length: 3 }, (_, i) => [
-        { source: `literal:recipe${i+1}`, predicate: "recipe://name", target: `Recipe ${i+1}`, author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-        { source: `literal:recipe${i+1}`, predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-      ]).flat(),
-      ...Array.from({ length: 2 }, (_, i) => [
-        { source: `literal:recipe${i+4}`, predicate: "recipe://name", target: `Recipe ${i+4}`, author: "did:key:bob", timestamp: "2023-01-02T00:00:00Z" },
-        { source: `literal:recipe${i+4}`, predicate: "recipe://rating", target: "5", author: "did:key:bob", timestamp: "2023-01-02T00:00:00Z" }
-      ]).flat()
-    ];
-    
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+  it("should apply filtering for author filtering in SPARQL count()", async () => {
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 3
+    });
 
     // Count recipes by Alice (should match 3 recipes)
     const count = await Recipe.count(mockPerspective, { where: { author: "did:key:alice" } }, 'sparql');
     
-    // Verify count matches the number of instances that would be returned by findAll
-    const findAllResults = await Recipe.findAll(mockPerspective, { where: { author: "did:key:alice" } }, 'sparql');
-    
     expect(count).toBe(3);
-    expect(count).toBe(findAllResults.length);
+    expect(mockPerspective.modelQuery).toHaveBeenCalled();
   });
 
-  it("should apply JS-level filtering in ModelQueryBuilder.count() with gt operator", async () => {
-    // Mock query results: 5 recipes with ratings 1, 2, 3, 4, 5
-    const queryResults = [
-      ...Array.from({ length: 5 }, (_, i) => [
-        { source: `literal:recipe${i+1}`, predicate: "recipe://name", target: `Recipe ${i+1}`, author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" },
-        { source: `literal:recipe${i+1}`, predicate: "recipe://rating", target: `${i+1}`, author: "did:key:alice", timestamp: "2023-01-01T00:00:00Z" }
-      ]).flat()
-    ];
-    
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+  it("should apply filtering in ModelQueryBuilder.count() with gt operator", async () => {
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 2
+    });
 
     // Count recipes with rating > 3 using ModelQueryBuilder
     const count = await Recipe.query(mockPerspective)
@@ -1107,26 +1046,15 @@ describe("Ad4mModel.count() with advanced where conditions", () => {
       .engine('sparql')
       .count();
     
-    // Verify count matches the number of instances that would be returned by get()
-    const getResults = await Recipe.query(mockPerspective)
-      .where({ rating: { gt: 3 } })
-      .engine('sparql')
-      .get();
-    
     expect(count).toBe(2);
-    expect(count).toBe(getResults.length);
+    expect(mockPerspective.modelQuery).toHaveBeenCalled();
   });
 
-  it("should apply JS-level filtering in ModelQueryBuilder.count() with timestamp between", async () => {
-    // Mock query results: 5 recipes with different timestamps
-    const queryResults = [
-      ...Array.from({ length: 5 }, (_, i) => [
-        { source: `literal:recipe${i+1}`, predicate: "recipe://name", target: `Recipe ${i+1}`, author: "did:key:alice", timestamp: `2023-01-0${i+1}T00:00:00Z` },
-        { source: `literal:recipe${i+1}`, predicate: "recipe://rating", target: "5", author: "did:key:alice", timestamp: `2023-01-0${i+1}T00:00:00Z` }
-      ]).flat()
-    ];
-    
-    mockPerspective.querySparql.mockResolvedValue(queryResults);
+  it("should apply filtering in ModelQueryBuilder.count() with timestamp between", async () => {
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [],
+      totalCount: 3
+    });
 
     const startTimestamp = new Date("2023-01-02T00:00:00Z").getTime();
     const endTimestamp = new Date("2023-01-04T00:00:00Z").getTime();
@@ -1137,14 +1065,8 @@ describe("Ad4mModel.count() with advanced where conditions", () => {
       .engine('sparql')
       .count();
     
-    // Verify count matches the number of instances that would be returned by get()
-    const getResults = await Recipe.query(mockPerspective)
-      .where({ timestamp: { between: [startTimestamp, endTimestamp] } })
-      .engine('sparql')
-      .get();
-    
     expect(count).toBe(3);
-    expect(count).toBe(getResults.length);
+    expect(mockPerspective.modelQuery).toHaveBeenCalled();
   });
 
   it("should handle count() with Prolog for gt operator (legacy)", async () => {

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -25,6 +25,120 @@ import type {
   PaginationResult, PropertyMetadata, RelationMetadata, ModelMetadata, ValueTuple,
 } from "./types";
 
+// ---------------------------------------------------------------------------
+// Helpers for Rust-side include resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively enrich relation metadata in the shape with target class shapes
+ * so the Rust endpoint can resolve includes in-process (no extra GraphQL
+ * round-trips per relation).
+ */
+function enrichShapeForIncludes(
+  metadata: ModelMetadata,
+  include: IncludeMap,
+  allRelMeta: Record<string, RelationMetadataEntry>,
+): void {
+  for (const [relName, includeVal] of Object.entries(include)) {
+    if (!includeVal) continue;
+    const meta = allRelMeta[relName];
+    if (!meta?.target) continue;
+
+    const TargetClass = meta.target() as typeof Ad4mModel;
+    // Deep-copy so we don't mutate the cached metadata
+    const targetMeta = JSON.parse(JSON.stringify(TargetClass.getModelMetadata()));
+
+    // Ensure the relation is in metadata.relations (hasOne/belongsToOne
+    // might not be there since getModelMetadata only puts hasMany/belongsToMany)
+    if (!metadata.relations[relName]) {
+      metadata.relations[relName] = {
+        name: relName,
+        predicate: meta.predicate,
+        direction:
+          meta.kind === 'belongsToMany' || meta.kind === 'belongsToOne'
+            ? 'reverse'
+            : 'forward',
+      };
+    }
+    const rel = metadata.relations[relName] as any;
+    rel.kind = meta.kind;
+    rel.maxCount = meta.maxCount;
+    rel.targetShape = targetMeta;
+    rel.targetClassName = targetMeta.className;
+
+    // Recurse for nested includes
+    const nested =
+      typeof includeVal === 'object' && includeVal !== null
+        ? (includeVal as any).include
+        : undefined;
+    if (nested) {
+      const targetRelMeta = getRelationsMetadata(TargetClass as any);
+      enrichShapeForIncludes(targetMeta, nested, targetRelMeta);
+    }
+  }
+}
+
+/**
+ * Construct a model class instance from a plain JSON object returned by the
+ * Rust endpoint.  Recursively converts included relation values (which come
+ * back as plain JSON objects) into proper model class instances.
+ */
+function jsonToModelInstance<T extends Ad4mModel>(
+  ModelClass: typeof Ad4mModel & (new (...args: any[]) => T),
+  perspective: PerspectiveProxy,
+  json: any,
+  include?: IncludeMap,
+): T {
+  const instance = new ModelClass(perspective, json.id || json.baseExpression) as any;
+
+  for (const [key, value] of Object.entries(json)) {
+    if (key === 'baseExpression' || key === 'id') continue;
+
+    // Skip getter-only properties anywhere in the prototype chain
+    let isReadonly = false;
+    let proto = Object.getPrototypeOf(instance);
+    while (proto) {
+      const desc = Object.getOwnPropertyDescriptor(proto, key);
+      if (desc) { isReadonly = !!(desc.get && !desc.set); break; }
+      proto = Object.getPrototypeOf(proto);
+    }
+    if (isReadonly) continue;
+
+    instance[key] = value;
+  }
+
+  // Recursively convert included relation values to class instances
+  if (include) {
+    const relMeta = getRelationsMetadata(ModelClass as any);
+    for (const [relName, includeVal] of Object.entries(include)) {
+      if (!includeVal) continue;
+      const meta = relMeta[relName];
+      if (!meta?.target) continue;
+      const TargetClass = meta.target() as any;
+      const nestedInclude =
+        typeof includeVal === 'object' && includeVal !== null
+          ? (includeVal as any).include
+          : undefined;
+
+      const raw = instance[relName];
+      if (Array.isArray(raw)) {
+        instance[relName] = raw.map((item: any) => {
+          if (typeof item === 'object' && item !== null && item.id) {
+            return jsonToModelInstance(TargetClass, perspective, item, nestedInclude);
+          }
+          return item;
+        });
+      } else if (typeof raw === 'object' && raw !== null && raw.id) {
+        instance[relName] = jsonToModelInstance(
+          TargetClass, perspective, raw, nestedInclude,
+        );
+      }
+    }
+  }
+
+  return instance;
+}
+
 /**
  * Base class for defining data models in AD4M.
  * 
@@ -1096,6 +1210,14 @@ export class Ad4mModel {
     if (query.limit !== undefined) queryInput.limit = query.limit;
     if (query.count !== undefined) queryInput.count = query.count;
 
+    // Enrich relation metadata with target class shapes for Rust-side
+    // include resolution. This eliminates per-relation GraphQL round-trips
+    // by letting the Rust endpoint resolve includes in-process.
+    if (query.include) {
+      const allRelMeta = getRelationsMetadata(this as any);
+      enrichShapeForIncludes(metadata, query.include, allRelMeta);
+    }
+
     // Send shape metadata to the executor so it knows the model structure.
     // This is more reliable than reading SHACL from the store because
     // the TS decorators are the definitive source of truth.
@@ -1104,31 +1226,11 @@ export class Ad4mModel {
 
     const result = await perspective.modelQuery(metadata.className, queryJson, shapeJson);
 
-    // Convert JSON instances to model class instances
+    // Convert JSON instances to model class instances, recursively constructing
+    // class instances for any included relations resolved by Rust.
     const instances: T[] = result.instances.map((json: any) => {
-      const instance = new this(perspective, json.id || json.baseExpression) as any;
-      // Assign all hydrated values from the executor response
-      for (const [key, value] of Object.entries(json)) {
-        if (key === 'baseExpression' || key === 'id') continue; // already set via constructor
-        // Skip getter-only properties anywhere in the prototype chain
-        // (e.g. timestamp on Ad4mModel.prototype, id on Ad4mModel.prototype)
-        let isReadonly = false;
-        let proto = Object.getPrototypeOf(instance);
-        while (proto) {
-          const desc = Object.getOwnPropertyDescriptor(proto, key);
-          if (desc) { isReadonly = !!(desc.get && !desc.set); break; }
-          proto = Object.getPrototypeOf(proto);
-        }
-        if (isReadonly) continue;
-        instance[key] = value;
-      }
-      return instance;
+      return jsonToModelInstance(this, perspective, json, query.include);
     });
-
-    // Eager-load relations if requested (uses TS-side relation resolution for now)
-    if (query.include && instances.length > 0) {
-      await hydrateRelations(this, instances, perspective, query.include);
-    }
 
     // Take snapshots for dirty tracking
     const snapshotRelations = query.include;

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -12,8 +12,6 @@ import { isArrayType, determinePredicate, determineNamespace, buildModelFromJSON
 import type { JSONSchemaProperty, JSONSchema, JSONSchemaToModelOptions } from "./json-schema";
 
 import { buildSPARQLQuery, buildSPARQLGetDataQuery, groupSPARQLResults, buildSPARQLCountQuery, hasJsOnlyWhereFilters, parseSparqlCount } from "./query-sparql";
-import { buildBatchSPARQLQuery } from "./query-sparql-batch";
-import { hydrateBatchResult } from "./hydration-batch";
 import { ModelQueryBuilder } from "./ModelQueryBuilder";
 import {
   normalizeValue, matchesCondition, hydrateFromLinks,
@@ -1066,6 +1064,85 @@ export class Ad4mModel {
   }
 
   /**
+   * Execute a model query via the executor-side endpoint.
+   * 
+   * This replaces the old SPARQL-build → hydrate → JS-filter → JS-sort → JS-paginate pipeline
+   * with a single RPC to the executor that handles everything in Rust.
+   * 
+   * @internal
+   */
+  private static async executeModelQuery<T extends Ad4mModel>(
+    this: typeof Ad4mModel & (new (...args: any[]) => T),
+    perspective: PerspectiveProxy,
+    query: Query = {},
+  ): Promise<ResultsWithTotalCount<T>> {
+    const metadata = this.getModelMetadata();
+
+    // Build the query input that the Rust endpoint expects.
+    // Convert the TS Query type to the executor's ModelQueryInput format.
+    const queryInput: any = {};
+    if (query.parent) {
+      const parentPredicate = resolveParentPredicate(query.parent, this);
+      queryInput.parent = { id: query.parent.id, predicate: parentPredicate };
+    }
+    if (query.properties) queryInput.properties = query.properties;
+    if (query.include) queryInput.include = query.include;
+    if (query.where) queryInput.where = query.where;
+    if (query.order) {
+      // Convert { propName: 'ASC' | 'DESC' } to [[propName, 'ASC'|'DESC'], ...]
+      queryInput.order = Object.entries(query.order).map(([k, v]) => [k, v]);
+    }
+    if (query.offset !== undefined) queryInput.offset = query.offset;
+    if (query.limit !== undefined) queryInput.limit = query.limit;
+    if (query.count !== undefined) queryInput.count = query.count;
+
+    // Send shape metadata to the executor so it knows the model structure.
+    // This is more reliable than reading SHACL from the store because
+    // the TS decorators are the definitive source of truth.
+    const shapeJson = JSON.stringify(metadata);
+    const queryJson = JSON.stringify(queryInput);
+
+    const result = await perspective.modelQuery(metadata.className, queryJson, shapeJson);
+
+    // Convert JSON instances to model class instances
+    const instances: T[] = result.instances.map((json: any) => {
+      const instance = new this(perspective, json.id || json.baseExpression) as any;
+      // Assign all hydrated values from the executor response
+      for (const [key, value] of Object.entries(json)) {
+        if (key === 'baseExpression' || key === 'id') continue; // already set via constructor
+        // Skip getter-only properties anywhere in the prototype chain
+        // (e.g. timestamp on Ad4mModel.prototype, id on Ad4mModel.prototype)
+        let isReadonly = false;
+        let proto = Object.getPrototypeOf(instance);
+        while (proto) {
+          const desc = Object.getOwnPropertyDescriptor(proto, key);
+          if (desc) { isReadonly = !!(desc.get && !desc.set); break; }
+          proto = Object.getPrototypeOf(proto);
+        }
+        if (isReadonly) continue;
+        instance[key] = value;
+      }
+      return instance;
+    });
+
+    // Eager-load relations if requested (uses TS-side relation resolution for now)
+    if (query.include && instances.length > 0) {
+      await hydrateRelations(this, instances, perspective, query.include);
+    }
+
+    // Take snapshots for dirty tracking
+    const snapshotRelations = query.include;
+    for (const inst of instances) {
+      (inst as Ad4mModel).takeSnapshot(snapshotRelations);
+    }
+
+    return {
+      results: instances,
+      totalCount: result.totalCount,
+    };
+  }
+
+  /**
    * Gets all instances of the model in the perspective that match the query params.
    * 
    * @param perspective - The perspective to search in
@@ -1108,14 +1185,7 @@ export class Ad4mModel {
       : engine;
 
     if (resolvedEngine === 'sparql') {
-      // Always use the regular SPARQL path + JS-level hydrateRelations for includes.
-      // The batch SPARQL approach had issues with sub-queries (where/order/limit on includes),
-      // non-conforming node filtering, and parse_literal compatibility.
-      // hydrateRelations handles all of these correctly via per-relation findAll calls.
-      const sparqlQuery = await this.queryToSPARQL(perspective, query);
-      const rawResult = await perspective.querySparql(sparqlQuery);
-      const grouped = groupSPARQLResults(rawResult);
-      const { results } = await this.instancesFromQueryResult(perspective, query, grouped);
+      const { results } = await this.executeModelQuery(perspective, query);
       return results;
     } else {
       const prologQuery = await this.queryToProlog(perspective, query);
@@ -1187,10 +1257,7 @@ export class Ad4mModel {
       : engine;
 
     if (resolvedEngine === 'sparql') {
-      const sparqlQuery = await this.queryToSPARQL(perspective, query);
-      const rawResult = await perspective.querySparql(sparqlQuery);
-      const grouped = groupSPARQLResults(rawResult);
-      return await this.instancesFromQueryResult(perspective, query, grouped, true);
+      return await this.executeModelQuery(perspective, query);
     } else {
       const prologQuery = await this.queryToProlog(perspective, query);
       const result = await perspective.infer(prologQuery);
@@ -1233,10 +1300,7 @@ export class Ad4mModel {
       : engine;
 
     if (resolvedEngine === 'sparql') {
-      const sparqlQuery = await this.queryToSPARQL(perspective, paginationQuery);
-      const rawResult = await perspective.querySparql(sparqlQuery);
-      const grouped = groupSPARQLResults(rawResult);
-      const { results, totalCount } = await this.instancesFromQueryResult(perspective, paginationQuery, grouped, true);
+      const { results, totalCount } = await this.executeModelQuery(perspective, paginationQuery);
       return { results, totalCount, pageSize, pageNumber };
     } else {
       const prologQuery = await this.queryToProlog(perspective, paginationQuery);
@@ -1307,21 +1371,8 @@ export class Ad4mModel {
       : engine;
 
     if (resolvedEngine === 'sparql') {
-      // When query has JS-only where filters (gt, between, author, timestamp, etc.),
-      // we must fall back to full hydration + JS filtering to get accurate count.
-      const metadata = this.getModelMetadata();
-      const allRelMeta = getRelationsMetadata(this as any);
-      if (hasJsOnlyWhereFilters(metadata, allRelMeta, query.where)) {
-        // Fall back to full query + JS filter path for accurate count
-        const sparqlQuery = await this.queryToSPARQL(perspective, query);
-        const rawResult = await perspective.querySparql(sparqlQuery);
-        const grouped = groupSPARQLResults(rawResult);
-        const { totalCount } = await this.instancesFromQueryResult(perspective, query, grouped, true);        return totalCount;
-      }
-      // No JS-only filters — use efficient COUNT query
-      const countSparql = await this.countQueryToSPARQL(perspective, query);
-      const countResult = await perspective.querySparql(countSparql);
-      return parseSparqlCount(countResult) ?? 0;
+      const { totalCount } = await this.executeModelQuery(perspective, { ...query, limit: 0 });
+      return totalCount;
     } else {
       const result = await perspective.infer(await this.countQueryToProlog(perspective, query));
       return result?.[0]?.TotalCount || 0;

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -48,8 +48,7 @@ function enrichShapeForIncludes(
     // Deep-copy so we don't mutate the cached metadata
     const targetMeta = JSON.parse(JSON.stringify(TargetClass.getModelMetadata()));
 
-    // Ensure the relation is in metadata.relations (hasOne/belongsToOne
-    // might not be there since getModelMetadata only puts hasMany/belongsToMany)
+    // Ensure the relation is in metadata.relations (fallback for edge cases)
     if (!metadata.relations[relName]) {
       metadata.relations[relName] = {
         name: relName,
@@ -88,8 +87,23 @@ function jsonToModelInstance<T extends Ad4mModel>(
   perspective: PerspectiveProxy,
   json: any,
   include?: IncludeMap,
+  properties?: string[],
 ): T {
   const instance = new ModelClass(perspective, json.id || json.baseExpression) as any;
+
+  // When a properties projection is active, remove own properties set by the
+  // constructor that are not in the projected JSON.  This ensures assertions
+  // like `expect(r).to.not.have.own.property("body")` pass.
+  if (properties) {
+    const jsonKeys = new Set(Object.keys(json));
+    for (const key of Object.getOwnPropertyNames(instance)) {
+      // Keep internal fields (backing store for getters), id, baseExpression, perspective
+      if (key === 'id' || key === 'baseExpression' || key === 'perspective' || key.startsWith('_')) continue;
+      if (!jsonKeys.has(key)) {
+        delete instance[key];
+      }
+    }
+  }
 
   for (const [key, value] of Object.entries(json)) {
     if (key === 'baseExpression' || key === 'id') continue;
@@ -119,18 +133,22 @@ function jsonToModelInstance<T extends Ad4mModel>(
         typeof includeVal === 'object' && includeVal !== null
           ? (includeVal as any).include
           : undefined;
+      const nestedProperties =
+        typeof includeVal === 'object' && includeVal !== null
+          ? (includeVal as any).properties
+          : undefined;
 
       const raw = instance[relName];
       if (Array.isArray(raw)) {
         instance[relName] = raw.map((item: any) => {
           if (typeof item === 'object' && item !== null && item.id) {
-            return jsonToModelInstance(TargetClass, perspective, item, nestedInclude);
+            return jsonToModelInstance(TargetClass, perspective, item, nestedInclude, nestedProperties);
           }
           return item;
         });
       } else if (typeof raw === 'object' && raw !== null && raw.id) {
         instance[relName] = jsonToModelInstance(
-          TargetClass, perspective, raw, nestedInclude,
+          TargetClass, perspective, raw, nestedInclude, nestedProperties,
         );
       }
     }
@@ -373,9 +391,7 @@ export class Ad4mModel {
     // Extract relations (relations) from WeakMap registry
     const relationsMetadata: Record<string, RelationMetadata> = {};
     const allRelationsMeta = getRelationsMetadata(this as any);
-    const prototypeRelations = Object.fromEntries(
-      Object.entries(allRelationsMeta).filter(([, r]) => r.kind === 'hasMany' || r.kind === 'belongsToMany')
-    );
+    const prototypeRelations = allRelationsMeta;
     
     for (const [relationName, opts] of Object.entries(prototypeRelations)) {
       const options = opts as RelationMetadataEntry;
@@ -385,6 +401,8 @@ export class Ad4mModel {
         ...(options.local !== undefined && { local: options.local }),
         ...(options.getter !== undefined && { getter: options.getter }),
         direction: (options.kind === 'belongsToMany' || options.kind === 'belongsToOne') ? 'reverse' : 'forward',
+        ...(options.kind !== undefined && { kind: options.kind }),
+        ...(options.maxCount !== undefined && { maxCount: options.maxCount }),
         ...(options.target !== undefined && { target: options.target }),
         ...(options.filter !== undefined && { filter: options.filter }),
         ...(options.where !== undefined && { where: options.where }),
@@ -1229,7 +1247,7 @@ export class Ad4mModel {
     // Convert JSON instances to model class instances, recursively constructing
     // class instances for any included relations resolved by Rust.
     const instances: T[] = result.instances.map((json: any) => {
-      return jsonToModelInstance(this, perspective, json, query.include);
+      return jsonToModelInstance(this, perspective, json, query.include, query.properties);
     });
 
     // Take snapshots for dirty tracking

--- a/core/src/model/ModelQueryBuilder.ts
+++ b/core/src/model/ModelQueryBuilder.ts
@@ -327,18 +327,16 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
   }
 
   /**
-   * Shared SPARQL query execution logic used by both get() and getSparql().
+   * Shared query execution logic — routes through the executor-side modelQuery endpoint.
    */
   private async executeSparqlQuery(): Promise<T[]> {
-    const sparqlQuery = await this.ctor.queryToSPARQL(this.perspective, this.queryParams);
-    const rawResult = await this.perspective.querySparql(sparqlQuery);
-    const { results } = await this.processSparqlResult(rawResult);
+    const { results } = await (this.ctor as any).executeModelQuery(this.perspective, this.queryParams);
     return results;
   }
 
   /**
    * Groups raw SPARQL results and hydrates them into model instances.
-   * Centralises the repeated groupSPARQLResults → instancesFromQueryResult pipeline.
+   * @deprecated — kept for subscription compatibility; new code uses executeModelQuery.
    */
   private async processSparqlResult(rawResult: any, queryOverride?: Query, computeTotalCount: boolean = false): Promise<{ results: T[], totalCount: number }> {
     const grouped = groupSPARQLResults(Array.isArray(rawResult) ? rawResult : []);
@@ -495,19 +493,8 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    */
   async count(): Promise<number> {
     if (this.engineFlag === 'sparql') {
-      // When query has JS-only where filters, fall back to full hydration
-      const metadata = this.ctor.getModelMetadata();
-      const allRelMeta = getRelationsMetadata(this.ctor as any);
-      if (hasJsOnlyWhereFilters(metadata, allRelMeta, this.queryParams.where)) {
-        const sparqlQuery = await this.ctor.queryToSPARQL(this.perspective, this.queryParams);
-        const rawResult = await this.perspective.querySparql(sparqlQuery);
-        const { totalCount } = await this.processSparqlResult(rawResult, undefined, true);
-        return totalCount;
-      }
-      // Use efficient COUNT query — no hydration
-      const countSparql = await this.ctor.countQueryToSPARQL(this.perspective, this.queryParams);
-      const countResult = await this.perspective.querySparql(countSparql);
-      return parseSparqlCount(countResult) ?? 0;
+      const { totalCount } = await (this.ctor as any).executeModelQuery(this.perspective, { ...this.queryParams, limit: 0 });
+      return totalCount;
     } else {
       const query = await this.ctor.countQueryToProlog(this.perspective, this.queryParams, this.modelClassName);
       const result = await this.perspective.infer(query);
@@ -631,9 +618,7 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
   async paginate(pageSize: number, pageNumber: number): Promise<PaginationResult<T>> {
     const paginationQuery = { ...(this.queryParams || {}), limit: pageSize, offset: pageSize * (pageNumber - 1), count: true };
     if (this.engineFlag === 'sparql') {
-      const sparqlQuery = await this.ctor.queryToSPARQL(this.perspective, paginationQuery);
-      const result = await this.perspective.querySparql(sparqlQuery);
-      const { results, totalCount } = await this.processSparqlResult(result, paginationQuery, true) as ResultsWithTotalCount<T>;
+      const { results, totalCount } = await (this.ctor as any).executeModelQuery(this.perspective, paginationQuery);
       return { results, totalCount, pageSize, pageNumber };
     } else {
       const prologQuery = await this.ctor.queryToProlog(this.perspective, paginationQuery, this.modelClassName);

--- a/core/src/perspectives/PerspectiveClient.ts
+++ b/core/src/perspectives/PerspectiveClient.ts
@@ -183,6 +183,17 @@ export class PerspectiveClient {
         return JSON.parse(perspectiveQuerySparql)
     }
 
+    async modelQuery(uuid: string, className: string, queryJson: string, shapeJson?: string): Promise<any> {
+        const { perspectiveModelQuery } = unwrapApolloResult(await this.#apolloClient.query({
+            query: gql`query perspectiveModelQuery($uuid: String!, $className: String!, $queryJson: String!, $shapeJson: String) {
+                perspectiveModelQuery(uuid: $uuid, className: $className, queryJson: $queryJson, shapeJson: $shapeJson)
+            }`,
+            variables: { uuid, className, queryJson, shapeJson: shapeJson || null }
+        }))
+
+        return JSON.parse(perspectiveModelQuery)
+    }
+
     async subscribeQuery(uuid: string, query: string): Promise<{ subscriptionId: string, result: AllInstancesResult, isInit?: boolean }> {
         const { perspectiveSubscribeQuery } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`mutation perspectiveSubscribeQuery($uuid: String!, $query: String!) {

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -579,6 +579,18 @@ export class PerspectiveProxy {
     }
 
     /**
+     * Execute a model query — the executor-side replacement for SPARQL query building + JS hydration.
+     * 
+     * @param className - The model class name (e.g. "Recipe")
+     * @param queryJson - Structured query as JSON string
+     * @param shapeJson - Optional shape metadata JSON from the model class
+     * @returns Object with `instances` array and `totalCount`
+     */
+    async modelQuery(className: string, queryJson: string, shapeJson?: string): Promise<{ instances: any[], totalCount: number }> {
+        return await this.#client.modelQuery(this.#handle.uuid, className, queryJson, shapeJson);
+    }
+
+    /**
      * Adds a new link to the perspective.
      * 
      * @param link - The link to add

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -671,6 +671,32 @@ impl Query {
         Ok(result)
     }
 
+    /// Model query — executor-side replacement for SPARQL query building + JS hydration.
+    /// Accepts a class name, structured query JSON, and optional shape metadata JSON.
+    /// Returns hydrated model instances as a JSON string.
+    async fn perspective_model_query(
+        &self,
+        context: &RequestContext,
+        uuid: String,
+        class_name: String,
+        query_json: String,
+        shape_json: Option<String>,
+    ) -> FieldResult<String> {
+        check_capability(
+            &context.capabilities,
+            &perspective_query_capability(vec![uuid.clone()]),
+        )?;
+
+        let result = get_perspective(&uuid)
+            .ok_or(FieldError::from(format!(
+                "No perspective found with uuid {}",
+                uuid
+            )))?
+            .model_query(&class_name, &query_json, shape_json.as_deref())?;
+
+        Ok(result)
+    }
+
     async fn perspective_snapshot(
         &self,
         context: &RequestContext,

--- a/rust-executor/src/perspectives/mod.rs
+++ b/rust-executor/src/perspectives/mod.rs
@@ -1,4 +1,5 @@
 pub mod migration;
+pub mod model_query;
 pub mod perspective_instance;
 pub mod sdna;
 pub mod shacl_parser;

--- a/rust-executor/src/perspectives/model_query.rs
+++ b/rust-executor/src/perspectives/model_query.rs
@@ -11,7 +11,7 @@
 //! 6. Returns JSON instances + totalCount
 
 use deno_core::anyhow::{anyhow, Error};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
@@ -60,6 +60,58 @@ pub enum OrderDirection {
     DESC,
 }
 
+/// Deserialize `order` from either `[["key","ASC"]]` (tuple array) or
+/// `{"key":"ASC"}` (object map).  Sub-query includes send the object form
+/// while the top-level query converts to tuples in TS.
+fn deserialize_order_flex<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<(String, OrderDirection)>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let val: Option<Value> = Option::deserialize(deserializer)?;
+    let val = match val {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    match val {
+        // Array of [key, direction] tuples
+        Value::Array(arr) => {
+            let mut out = Vec::new();
+            for item in arr {
+                if let Value::Array(pair) = item {
+                    if pair.len() == 2 {
+                        let key = pair[0].as_str().unwrap_or("").to_string();
+                        let dir_str = pair[1].as_str().unwrap_or("ASC");
+                        let dir = if dir_str.eq_ignore_ascii_case("desc") {
+                            OrderDirection::DESC
+                        } else {
+                            OrderDirection::ASC
+                        };
+                        out.push((key, dir));
+                    }
+                }
+            }
+            Ok(Some(out))
+        }
+        // Object map { key: direction }
+        Value::Object(map) => {
+            let mut out = Vec::new();
+            for (key, dir_val) in map {
+                let dir_str = dir_val.as_str().unwrap_or("ASC");
+                let dir = if dir_str.eq_ignore_ascii_case("desc") {
+                    OrderDirection::DESC
+                } else {
+                    OrderDirection::ASC
+                };
+                out.push((key, dir));
+            }
+            Ok(Some(out))
+        }
+        _ => Ok(None),
+    }
+}
+
 /// Parent scope for scoped queries.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
@@ -95,7 +147,7 @@ pub struct ModelQueryInput {
     pub include: Option<HashMap<String, IncludeValue>>,
     #[serde(default, rename = "where")]
     pub where_clause: Option<HashMap<String, WhereCondition>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_order_flex")]
     pub order: Option<Vec<(String, OrderDirection)>>,
     #[serde(default)]
     pub offset: Option<usize>,
@@ -129,6 +181,8 @@ struct ShapeProperty {
     initial_value: Option<String>,
     resolve_language: Option<String>,
     datatype: Option<String>,
+    direction: Option<String>, // "forward" or "reverse" for relation properties
+    is_scalar_relation: bool,  // true for hasOne/belongsToOne (render as scalar, not array)
 }
 
 /// Enriched relation metadata for include (eager-loading) resolution.
@@ -343,6 +397,8 @@ fn load_shape(store: &SparqlStore, class_name: &str) -> Result<ModelShape, Error
             initial_value,
             resolve_language,
             datatype,
+            direction: None,
+            is_scalar_relation: false,
         });
     }
 
@@ -452,9 +508,21 @@ pub fn execute_model_query(
     // Hydrate instances from grouped results
     let mut instances = hydrate_instances(&shape, &grouped);
 
+    // Resolve reverse relations (BelongsToOne / BelongsToMany) — these are
+    // links pointing TO our instances and aren't captured by the main SPARQL.
+    let reverse_rels: Vec<(String, String, bool)> = shape
+        .properties
+        .iter()
+        .filter(|p| p.direction.as_deref() == Some("reverse"))
+        .map(|p| (p.name.clone(), p.predicate.clone(), p.is_scalar_relation))
+        .collect();
+    if !reverse_rels.is_empty() && !instances.is_empty() {
+        resolve_reverse_relations(store, &mut instances, &reverse_rels)?;
+    }
+
     // Apply where-clause filters
     if let Some(ref where_clause) = query_input.where_clause {
-        instances.retain(|inst| matches_where(inst, where_clause));
+        instances.retain(|inst| matches_where(inst, where_clause, &shape));
     }
 
     // Calculate total count before pagination
@@ -546,6 +614,8 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
                 initial_value: initial,
                 resolve_language,
                 datatype,
+                direction: None,
+                is_scalar_relation: false,
             });
         }
     }
@@ -558,15 +628,22 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
                 continue;
             }
 
+            let direction = rel_meta["direction"].as_str().map(|s| s.to_string());
+
+            let kind = rel_meta["kind"].as_str().unwrap_or("hasMany").to_string();
+            let is_scalar_relation = kind == "hasOne" || kind == "belongsToOne";
+
             properties.push(ShapeProperty {
                 name: name.clone(),
                 predicate: predicate.clone(),
-                is_collection: true,
+                is_collection: true, // always accumulate as array during hydration
                 is_flag: false,
                 is_required: false,
                 initial_value: None,
                 resolve_language: None,
                 datatype: None,
+                direction: direction.clone(),
+                is_scalar_relation,
             });
 
             // Parse enriched relation metadata (target shapes for include resolution)
@@ -645,34 +722,38 @@ fn build_count_sparql(shape: &ModelShape, query: &ModelQueryInput) -> String {
 }
 
 /// Check whether a query's where clause contains only conditions that can be
-/// pushed to SPARQL (string equality, boolean equality, id/base filters).
-/// If true, a COUNT query can run entirely in SPARQL without hydration.
+/// pushed entirely to SPARQL.  If true, a COUNT query can skip hydration.
+///
+/// Only id/base filters and relation-based where (which match plain URIs, not
+/// signed envelopes) are SPARQL-pushable.  Property equality is NOT pushable
+/// because stored values are signed JSON envelopes.
 fn all_where_pushable(query: &ModelQueryInput, shape: &ModelShape) -> bool {
     let Some(ref wc) = query.where_clause else {
         return true;
     };
     for (prop_name, condition) in wc {
         if prop_name == "base" || prop_name == "id" {
-            if matches!(condition, WhereCondition::String(_)) {
+            match condition {
+                WhereCondition::String(_) | WhereCondition::StringArray(_) => continue,
+                _ => return false,
+            }
+        }
+        // Relation-based where (forward or reverse) can be pushed
+        if shape
+            .properties
+            .iter()
+            .any(|p| p.name == *prop_name && p.is_collection)
+        {
+            if matches!(
+                condition,
+                WhereCondition::String(_) | WhereCondition::StringArray(_)
+            ) {
                 continue;
             }
             return false;
         }
-        if prop_name == "author"
-            || prop_name == "timestamp"
-            || prop_name == "createdAt"
-            || prop_name == "updatedAt"
-        {
-            return false;
-        }
-        if shape.properties.iter().any(|p| p.name == *prop_name) {
-            match condition {
-                WhereCondition::String(_) | WhereCondition::Bool(_) => continue,
-                _ => return false,
-            }
-        } else {
-            return false;
-        }
+        // All other conditions (property values, metadata, ops) need post-hydration
+        return false;
     }
     true
 }
@@ -765,45 +846,91 @@ fn build_query_patterns(shape: &ModelShape, query: &ModelQueryInput) -> (String,
         }
     }
 
-    // WHERE clause filters that can be pushed to SPARQL (equality, IN)
+    // WHERE clause filters that can be pushed to SPARQL.
+    //
+    // Property equality CANNOT be pushed because stored values are signed JSON
+    // envelopes (`literal:json:{author,timestamp,data,proof}`), not plain
+    // `literal:string:X`.  Only id/base and relation-based where can be pushed.
     let mut where_patterns = Vec::new();
     if let Some(ref wc) = query.where_clause {
         for (prop_name, condition) in wc {
             if prop_name == "base" || prop_name == "id" {
-                // Filter by base expression URI directly
-                if let WhereCondition::String(val) = condition {
-                    where_patterns.push(format!("    FILTER(?source = <{}>)", val));
+                match condition {
+                    WhereCondition::String(val) => {
+                        // Use STR() comparison to avoid IRI parsing issues with
+                        // literal:json URIs that contain encoded special chars
+                        where_patterns.push(format!(
+                            "    FILTER(STR(?source) = \"{}\")",
+                            val.replace('\\', "\\\\").replace('"', "\\\"")
+                        ));
+                    }
+                    WhereCondition::StringArray(vals) => {
+                        let ids = vals
+                            .iter()
+                            .map(|v| {
+                                format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\""))
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        where_patterns.push(format!("    FILTER(STR(?source) IN ({}))", ids));
+                    }
+                    _ => {} // complex id ops handled post-hydration
                 }
-                continue;
-            }
-            // Skip author/timestamp — handled post-hydration
-            if prop_name == "author"
-                || prop_name == "timestamp"
-                || prop_name == "createdAt"
-                || prop_name == "updatedAt"
-            {
                 continue;
             }
 
-            // Find the property metadata
-            if let Some(prop) = shape.properties.iter().find(|p| &p.name == prop_name) {
-                // Only push simple equality to SPARQL
+            // Relation-based where: link targets are plain URIs (not signed),
+            // so we CAN push these to SPARQL.  Use STR() comparison to avoid
+            // IRI parsing failures with literal:json URIs.
+            if let Some(prop) = shape
+                .properties
+                .iter()
+                .find(|p| &p.name == prop_name && p.is_collection)
+            {
+                let direction = prop.direction.as_deref().unwrap_or("forward");
+                let safe_name = prop_name.replace(|c: char| !c.is_alphanumeric(), "_");
                 match condition {
                     WhereCondition::String(val) => {
-                        let iri_val = value_to_literal_iri_string(val);
-                        where_patterns
-                            .push(format!("    ?source <{}> <{}> .", prop.predicate, iri_val));
+                        let escaped = val.replace('\\', "\\\\").replace('"', "\\\"");
+                        if direction == "reverse" {
+                            where_patterns.push(format!(
+                                "    ?_rv_{} <{}> ?source . FILTER(STR(?_rv_{}) = \"{}\")",
+                                safe_name, prop.predicate, safe_name, escaped
+                            ));
+                        } else {
+                            where_patterns.push(format!(
+                                "    ?source <{}> ?_ft_{} . FILTER(STR(?_ft_{}) = \"{}\")",
+                                prop.predicate, safe_name, safe_name, escaped
+                            ));
+                        }
                     }
-                    WhereCondition::Bool(val) => {
-                        let iri_val = format!("literal:boolean:{}", val);
-                        where_patterns
-                            .push(format!("    ?source <{}> <{}> .", prop.predicate, iri_val));
+                    WhereCondition::StringArray(vals) => {
+                        let str_list = vals
+                            .iter()
+                            .map(|v| {
+                                format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\""))
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        if direction == "reverse" {
+                            where_patterns.push(format!(
+                                "    ?_rv_{} <{}> ?source . FILTER(STR(?_rv_{}) IN ({}))",
+                                safe_name, prop.predicate, safe_name, str_list
+                            ));
+                        } else {
+                            where_patterns.push(format!(
+                                "    ?source <{}> ?_ft_{} . FILTER(STR(?_ft_{}) IN ({}))",
+                                prop.predicate, safe_name, safe_name, str_list
+                            ));
+                        }
                     }
-                    _ => {
-                        // Complex conditions (comparison ops, arrays, etc.) handled post-hydration
-                    }
+                    _ => {} // complex ops handled post-hydration
                 }
+                continue;
             }
+
+            // All other conditions (property values, metadata, ops) are
+            // handled post-hydration in matches_where().
         }
     }
 
@@ -964,19 +1091,39 @@ fn hydrate_one(shape: &ModelShape, inst: &InstanceLinks) -> Option<Value> {
     for (name, mut values) in collection_values {
         // Sort by timestamp (chronological)
         values.sort_by_key(|&(_, ts)| ts);
+        // Check if this is a relation property (has a direction) — if so, keep
+        // raw IRIs for later include resolution lookup rather than extracting
+        // the inner data value from signed envelopes.
+        let is_relation = shape
+            .properties
+            .iter()
+            .any(|p| p.name == name && p.direction.is_some());
         let arr: Vec<Value> = values
             .iter()
             .map(|&(target, _)| {
-                // For collections, the target is typically a URI (relation ID)
-                // not a literal: value
-                if target.starts_with("literal:") {
+                if is_relation {
+                    // Keep raw IRI so resolve_forward_include can match by id
+                    Value::String(target.to_string())
+                } else if target.starts_with("literal:") {
                     parse_literal_value(target)
                 } else {
                     Value::String(target.to_string())
                 }
             })
             .collect();
-        obj.insert(name.to_string(), Value::Array(arr));
+        // Check if this is a scalar relation (hasOne/belongsToOne) — if so,
+        // unwrap the first element as a scalar value instead of an array.
+        let is_scalar = shape
+            .properties
+            .iter()
+            .any(|p| p.name == name && p.is_scalar_relation);
+        if is_scalar {
+            if let Some(first) = arr.into_iter().next() {
+                obj.insert(name.to_string(), first);
+            }
+        } else {
+            obj.insert(name.to_string(), Value::Array(arr));
+        }
     }
 
     // Set metadata
@@ -1003,11 +1150,40 @@ fn hydrate_one(shape: &ModelShape, inst: &InstanceLinks) -> Option<Value> {
 // ---------------------------------------------------------------------------
 
 /// Check if an instance matches all where-clause conditions.
-fn matches_where(instance: &Value, where_clause: &HashMap<String, WhereCondition>) -> bool {
+fn matches_where(
+    instance: &Value,
+    where_clause: &HashMap<String, WhereCondition>,
+    shape: &ModelShape,
+) -> bool {
     for (prop_name, condition) in where_clause {
         if prop_name == "base" || prop_name == "id" {
-            // Already filtered in SPARQL
-            continue;
+            // String and StringArray id conditions are pushed to SPARQL.
+            // Complex ops (Ops, NumberArray, etc.) still need post-hydration.
+            match condition {
+                WhereCondition::String(_) | WhereCondition::StringArray(_) => continue,
+                _ => {
+                    let val = &instance[prop_name];
+                    if !matches_condition(val, condition) {
+                        return false;
+                    }
+                    continue;
+                }
+            }
+        }
+
+        // Relation-based where conditions (String/StringArray on collection props)
+        // are already pushed to SPARQL — skip them here.
+        if matches!(
+            condition,
+            WhereCondition::String(_) | WhereCondition::StringArray(_)
+        ) {
+            if shape
+                .properties
+                .iter()
+                .any(|p| p.name == *prop_name && p.is_collection)
+            {
+                continue;
+            }
         }
 
         let val = &instance[prop_name];
@@ -1458,8 +1634,20 @@ fn resolve_forward_include(
     // Build a query: where.id = [...allIds] merged with any sub-query filters
     let mut query = sub_query.clone();
     let mut wc = query.where_clause.take().unwrap_or_default();
+
+    // If the sub-query has its own id filter, intersect with parent IDs
+    if let Some(existing_id) = wc.get("id") {
+        let filter_ids: Vec<String> = match existing_id {
+            WhereCondition::String(s) => vec![s.clone()],
+            WhereCondition::StringArray(arr) => arr.clone(),
+            _ => vec![],
+        };
+        all_ids.retain(|id| filter_ids.contains(id));
+    }
     wc.insert("id".to_string(), WhereCondition::StringArray(all_ids));
     query.where_clause = Some(wc);
+
+    let has_sub_order = sub_query.order.is_some();
 
     let result = execute_model_query(
         store,
@@ -1468,8 +1656,13 @@ fn resolve_forward_include(
         Some(&rel.target_shape_json),
     )?;
 
-    // Build id → hydrated instance map
+    // Build id → hydrated instance map + ordered ID list
     let mut hydrated: HashMap<String, Value> = HashMap::new();
+    let ordered_ids: Vec<String> = result
+        .instances
+        .iter()
+        .filter_map(|inst| inst["id"].as_str().map(|s| s.to_string()))
+        .collect();
     for inst in result.instances {
         if let Some(id) = inst["id"].as_str() {
             hydrated.insert(id.to_string(), inst);
@@ -1479,21 +1672,36 @@ fn resolve_forward_include(
     // Replace string IDs with hydrated objects on each parent instance
     for inst in instances.iter_mut() {
         let raw = inst[&rel.name].clone();
-        let resolved = if let Some(arr) = raw.as_array() {
-            let items: Vec<Value> = arr
-                .iter()
-                .filter_map(|item| item.as_str().and_then(|id| hydrated.get(id).cloned()))
-                .collect();
-            // hasOne (maxCount==1): unwrap to single value
-            if rel.max_count == Some(1) {
-                items.last().cloned().unwrap_or(Value::Null)
-            } else {
-                Value::Array(items)
-            }
+        let parent_ids: Vec<String> = if let Some(arr) = raw.as_array() {
+            arr.iter()
+                .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                .collect()
         } else if let Some(id) = raw.as_str() {
-            hydrated.get(id).cloned().unwrap_or(Value::Null)
+            vec![id.to_string()]
         } else {
             continue;
+        };
+
+        // When sub-query has an order, use result order (filtered to this parent's IDs)
+        let iter_ids: Vec<&str> = if has_sub_order {
+            ordered_ids
+                .iter()
+                .filter(|id| parent_ids.iter().any(|pid| pid == *id))
+                .map(|s| s.as_str())
+                .collect()
+        } else {
+            parent_ids.iter().map(|s| s.as_str()).collect()
+        };
+
+        let items: Vec<Value> = iter_ids
+            .iter()
+            .filter_map(|id| hydrated.get(*id).cloned())
+            .collect();
+
+        let resolved = if rel.max_count == Some(1) {
+            items.last().cloned().unwrap_or(Value::Null)
+        } else {
+            Value::Array(items)
         };
         inst.as_object_mut()
             .map(|obj| obj.insert(rel.name.clone(), resolved));
@@ -1557,15 +1765,33 @@ fn resolve_reverse_include(
     };
 
     // Hydrate source instances
-    let hydrated: HashMap<String, Value> = if all_source_ids.is_empty() {
-        HashMap::new()
+    let has_sub_order = sub_query.order.is_some();
+    let hydrated: HashMap<String, Value>;
+    let ordered_result_ids: Vec<String>;
+    if all_source_ids.is_empty() {
+        hydrated = HashMap::new();
+        ordered_result_ids = Vec::new();
     } else {
         let mut query = sub_query.clone();
         let mut wc = query.where_clause.take().unwrap_or_default();
-        wc.insert(
-            "id".to_string(),
-            WhereCondition::StringArray(all_source_ids),
-        );
+        // Intersect sub-query id filter with source IDs if present
+        if let Some(existing_id) = wc.get("id") {
+            let filter_ids: Vec<String> = match existing_id {
+                WhereCondition::String(s) => vec![s.clone()],
+                WhereCondition::StringArray(arr) => arr.clone(),
+                _ => vec![],
+            };
+            let filtered: Vec<String> = all_source_ids
+                .into_iter()
+                .filter(|id| filter_ids.contains(id))
+                .collect();
+            wc.insert("id".to_string(), WhereCondition::StringArray(filtered));
+        } else {
+            wc.insert(
+                "id".to_string(),
+                WhereCondition::StringArray(all_source_ids),
+            );
+        }
         query.where_clause = Some(wc);
 
         let result = execute_model_query(
@@ -1575,13 +1801,18 @@ fn resolve_reverse_include(
             Some(&rel.target_shape_json),
         )?;
 
+        ordered_result_ids = result
+            .instances
+            .iter()
+            .filter_map(|inst| inst["id"].as_str().map(|s| s.to_string()))
+            .collect();
         let mut map = HashMap::new();
         for inst in result.instances {
             if let Some(id) = inst["id"].as_str() {
                 map.insert(id.to_string(), inst);
             }
         }
-        map
+        hydrated = map;
     };
 
     // Assign hydrated instances to each parent
@@ -1595,9 +1826,19 @@ fn resolve_reverse_include(
                 .and_then(|id| hydrated.get(id).cloned())
                 .unwrap_or(Value::Null)
         } else {
-            let items: Vec<Value> = source_ids
+            // When sub-query has order, use result order filtered to this parent's source IDs
+            let iter_ids: Vec<&str> = if has_sub_order {
+                ordered_result_ids
+                    .iter()
+                    .filter(|id| source_ids.contains(id))
+                    .map(|s| s.as_str())
+                    .collect()
+            } else {
+                source_ids.iter().map(|s| s.as_str()).collect()
+            };
+            let items: Vec<Value> = iter_ids
                 .iter()
-                .filter_map(|id| hydrated.get(id).cloned())
+                .filter_map(|id| hydrated.get(*id).cloned())
                 .collect();
             Value::Array(items)
         };

--- a/rust-executor/src/perspectives/model_query.rs
+++ b/rust-executor/src/perspectives/model_query.rs
@@ -137,8 +137,8 @@ struct ShapeProperty {
 struct ShapeRelation {
     name: String,
     predicate: String,
-    direction: String,         // "forward" or "reverse"
-    kind: String,              // "hasMany", "hasOne", "belongsToOne", "belongsToMany"
+    direction: String, // "forward" or "reverse"
+    kind: String,      // "hasMany", "hasOne", "belongsToOne", "belongsToMany"
     max_count: Option<usize>,
     target_class_name: String,
     target_shape_json: String, // Serialised ModelMetadata JSON for recursive queries
@@ -418,8 +418,7 @@ pub fn execute_model_query(
     // When the caller only needs a count (limit==0 or count==true) and all
     // where conditions can be pushed to SPARQL, we skip hydration entirely
     // and run a single SELECT COUNT(DISTINCT ?source) query.
-    let is_count_only =
-        query_input.count == Some(true) || query_input.limit == Some(0);
+    let is_count_only = query_input.count == Some(true) || query_input.limit == Some(0);
     if is_count_only && all_where_pushable(query_input, &shape) {
         let sparql = build_count_sparql(&shape, query_input);
         let result_json = store.query(&sparql)?;
@@ -519,10 +518,7 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
     let meta: Value =
         serde_json::from_str(json).map_err(|e| anyhow!("Failed to parse shape JSON: {}", e))?;
 
-    let target_class = meta["className"]
-        .as_str()
-        .unwrap_or(class_name)
-        .to_string();
+    let target_class = meta["className"].as_str().unwrap_or(class_name).to_string();
 
     let mut properties = Vec::new();
     let mut include_relations: Vec<ShapeRelation> = Vec::new();
@@ -581,10 +577,7 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
                     .or_else(|| target_shape["className"].as_str())
                     .unwrap_or("")
                     .to_string();
-                let kind = rel_meta["kind"]
-                    .as_str()
-                    .unwrap_or("hasMany")
-                    .to_string();
+                let kind = rel_meta["kind"].as_str().unwrap_or("hasMany").to_string();
                 let direction = rel_meta["direction"]
                     .as_str()
                     .unwrap_or("forward")
@@ -598,8 +591,7 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
                     kind,
                     max_count,
                     target_class_name,
-                    target_shape_json: serde_json::to_string(target_shape)
-                        .unwrap_or_default(),
+                    target_shape_json: serde_json::to_string(target_shape).unwrap_or_default(),
                 });
             }
         }
@@ -694,19 +686,16 @@ fn build_query_patterns(shape: &ModelShape, query: &ModelQueryInput) -> (String,
     if let Some(ref parent) = query.parent {
         match parent {
             ParentScope::Raw { id, predicate } => {
-                conformance_patterns
-                    .push(format!("    <{}> <{}> ?source .", id, predicate));
+                conformance_patterns.push(format!("    <{}> <{}> ?source .", id, predicate));
             }
             ParentScope::Model { id, field, model } => {
                 // For model-based parent scope, we need to resolve the predicate
                 // The client should send the resolved predicate, but we handle both forms
                 if let Some(ref f) = field {
-                    conformance_patterns
-                        .push(format!("    <{}> <{}> ?source .", id, f));
+                    conformance_patterns.push(format!("    <{}> <{}> ?source .", id, f));
                 } else {
                     // Fallback: use model name as predicate hint
-                    conformance_patterns
-                        .push(format!("    <{}> ?_parentPred ?source .", id));
+                    conformance_patterns.push(format!("    <{}> ?_parentPred ?source .", id));
                     conformance_patterns.push(format!(
                         "    FILTER(STRENDS(STR(?_parentPred), \"{}\"))",
                         model
@@ -783,15 +772,16 @@ fn build_query_patterns(shape: &ModelShape, query: &ModelQueryInput) -> (String,
             if prop_name == "base" || prop_name == "id" {
                 // Filter by base expression URI directly
                 if let WhereCondition::String(val) = condition {
-                    where_patterns.push(format!(
-                        "    FILTER(?source = <{}>)",
-                        val
-                    ));
+                    where_patterns.push(format!("    FILTER(?source = <{}>)", val));
                 }
                 continue;
             }
             // Skip author/timestamp — handled post-hydration
-            if prop_name == "author" || prop_name == "timestamp" || prop_name == "createdAt" || prop_name == "updatedAt" {
+            if prop_name == "author"
+                || prop_name == "timestamp"
+                || prop_name == "createdAt"
+                || prop_name == "updatedAt"
+            {
                 continue;
             }
 
@@ -801,17 +791,13 @@ fn build_query_patterns(shape: &ModelShape, query: &ModelQueryInput) -> (String,
                 match condition {
                     WhereCondition::String(val) => {
                         let iri_val = value_to_literal_iri_string(val);
-                        where_patterns.push(format!(
-                            "    ?source <{}> <{}> .",
-                            prop.predicate, iri_val
-                        ));
+                        where_patterns
+                            .push(format!("    ?source <{}> <{}> .", prop.predicate, iri_val));
                     }
                     WhereCondition::Bool(val) => {
                         let iri_val = format!("literal:boolean:{}", val);
-                        where_patterns.push(format!(
-                            "    ?source <{}> <{}> .",
-                            prop.predicate, iri_val
-                        ));
+                        where_patterns
+                            .push(format!("    ?source <{}> <{}> .", prop.predicate, iri_val));
                     }
                     _ => {
                         // Complex conditions (comparison ops, arrays, etc.) handled post-hydration
@@ -1096,12 +1082,10 @@ fn matches_ops(val: &Value, ops: &WhereOps) -> bool {
                 for item in arr {
                     if match (val, item) {
                         (Value::String(v), Value::String(s)) => v == s,
-                        (Value::Number(_), Value::Number(_)) => {
-                            to_f64(val)
-                                .zip(item.as_f64())
-                                .map(|(a, b)| (a - b).abs() < f64::EPSILON)
-                                .unwrap_or(false)
-                        }
+                        (Value::Number(_), Value::Number(_)) => to_f64(val)
+                            .zip(item.as_f64())
+                            .map(|(a, b)| (a - b).abs() < f64::EPSILON)
+                            .unwrap_or(false),
                         _ => false,
                     } {
                         return false;
@@ -1258,9 +1242,7 @@ fn compare_values(a: &Value, b: &Value) -> Ordering {
 
     // Try numeric comparison first
     if let (Some(an), Some(bn)) = (to_f64(a), to_f64(b)) {
-        return an
-            .partial_cmp(&bn)
-            .unwrap_or(Ordering::Equal);
+        return an.partial_cmp(&bn).unwrap_or(Ordering::Equal);
     }
 
     // String comparison
@@ -1381,8 +1363,10 @@ pub(crate) fn resolve_includes(
             let related_links =
                 store.query_links(Some(&id), Some(&prop.predicate), None, None, None, None)?;
 
-            let related_ids: Vec<String> =
-                related_links.iter().map(|l| l.data.target.clone()).collect();
+            let related_ids: Vec<String> = related_links
+                .iter()
+                .map(|l| l.data.target.clone())
+                .collect();
 
             // If there's a sub-query with its own class, we'd need to recursively query
             // For now, just set the IDs
@@ -1498,9 +1482,7 @@ fn resolve_forward_include(
         let resolved = if let Some(arr) = raw.as_array() {
             let items: Vec<Value> = arr
                 .iter()
-                .filter_map(|item| {
-                    item.as_str().and_then(|id| hydrated.get(id).cloned())
-                })
+                .filter_map(|item| item.as_str().and_then(|id| hydrated.get(id).cloned()))
                 .collect();
             // hasOne (maxCount==1): unwrap to single value
             if rel.max_count == Some(1) {
@@ -1605,10 +1587,7 @@ fn resolve_reverse_include(
     // Assign hydrated instances to each parent
     for inst in instances.iter_mut() {
         let inst_id = inst["id"].as_str().unwrap_or("").to_string();
-        let source_ids = sources_by_target
-            .get(&inst_id)
-            .cloned()
-            .unwrap_or_default();
+        let source_ids = sources_by_target.get(&inst_id).cloned().unwrap_or_default();
 
         let resolved = if rel.kind == "belongsToOne" || rel.max_count == Some(1) {
             source_ids
@@ -1803,10 +1782,7 @@ mod tests {
             json!({"name": "A", "age": 10}),
             json!({"name": "B", "age": 20}),
         ];
-        sort_instances(
-            &mut instances,
-            &[("age".to_string(), OrderDirection::ASC)],
-        );
+        sort_instances(&mut instances, &[("age".to_string(), OrderDirection::ASC)]);
         assert_eq!(instances[0]["age"], 10);
         assert_eq!(instances[1]["age"], 20);
         assert_eq!(instances[2]["age"], 30);
@@ -1821,10 +1797,7 @@ mod tests {
             "age": 25,
             "secret": "hidden"
         });
-        let filtered = filter_properties(
-            inst,
-            &["name".to_string(), "age".to_string()],
-        );
+        let filtered = filter_properties(inst, &["name".to_string(), "age".to_string()]);
         assert!(filtered.get("id").is_some());
         assert!(filtered.get("name").is_some());
         assert!(filtered.get("age").is_some());
@@ -1856,8 +1829,14 @@ mod tests {
         let shape = parse_shape_from_json(json, "Recipe").unwrap();
         assert_eq!(shape.target_class, "Recipe");
         assert_eq!(shape.properties.len(), 3);
-        assert!(shape.properties.iter().any(|p| p.name == "name" && p.is_required));
-        assert!(shape.properties.iter().any(|p| p.name == "ingredients" && p.is_collection));
+        assert!(shape
+            .properties
+            .iter()
+            .any(|p| p.name == "name" && p.is_required));
+        assert!(shape
+            .properties
+            .iter()
+            .any(|p| p.name == "ingredients" && p.is_collection));
     }
 }
 

--- a/rust-executor/src/perspectives/model_query.rs
+++ b/rust-executor/src/perspectives/model_query.rs
@@ -1,0 +1,1499 @@
+//! Executor-side model query engine.
+//!
+//! Replaces the TS-side SPARQL-build → hydrate → JS-filter → JS-sort → JS-paginate
+//! pipeline with a single Rust function that:
+//!
+//! 1. Reads the SHACL shape from the perspective's link store
+//! 2. Builds conformance SPARQL internally
+//! 3. Hydrates instances by parsing `literal:` URIs natively (typed)
+//! 4. Filters with correct typed comparisons
+//! 5. Sorts and paginates in Rust
+//! 6. Returns JSON instances + totalCount
+
+use deno_core::anyhow::{anyhow, Error};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashMap};
+
+use super::sparql_store::SparqlStore;
+
+// ---------------------------------------------------------------------------
+// Query DSL types (mirrors TS types.ts)
+// ---------------------------------------------------------------------------
+
+/// Comparison operators for where conditions.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WhereOps {
+    #[serde(default)]
+    pub not: Option<Value>,
+    #[serde(default)]
+    pub between: Option<(f64, f64)>,
+    #[serde(default)]
+    pub lt: Option<f64>,
+    #[serde(default)]
+    pub lte: Option<f64>,
+    #[serde(default)]
+    pub gt: Option<f64>,
+    #[serde(default)]
+    pub gte: Option<f64>,
+    #[serde(default)]
+    pub contains: Option<Value>,
+}
+
+/// A single where condition: simple value or operator object.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum WhereCondition {
+    String(String),
+    Number(f64),
+    Bool(bool),
+    StringArray(Vec<String>),
+    NumberArray(Vec<f64>),
+    Ops(WhereOps),
+}
+
+/// Order direction.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+pub enum OrderDirection {
+    ASC,
+    DESC,
+}
+
+/// Parent scope for scoped queries.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ParentScope {
+    Model {
+        model: String,
+        id: String,
+        field: Option<String>,
+    },
+    Raw {
+        id: String,
+        predicate: String,
+    },
+}
+
+/// Include map for eager-loading relations.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum IncludeValue {
+    Bool(bool),
+    SubQuery(Box<ModelQueryInput>),
+}
+
+/// The structured query input (mirrors TS Query type).
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelQueryInput {
+    #[serde(default)]
+    pub parent: Option<ParentScope>,
+    #[serde(default)]
+    pub properties: Option<Vec<String>>,
+    #[serde(default)]
+    pub include: Option<HashMap<String, IncludeValue>>,
+    #[serde(default, rename = "where")]
+    pub where_clause: Option<HashMap<String, WhereCondition>>,
+    #[serde(default)]
+    pub order: Option<Vec<(String, OrderDirection)>>,
+    #[serde(default)]
+    pub offset: Option<usize>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub count: Option<bool>,
+}
+
+/// Result returned by the model query endpoint.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelQueryResult {
+    pub instances: Vec<Value>,
+    pub total_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Internal shape info (derived from SHACL links in the store)
+// ---------------------------------------------------------------------------
+
+/// A property discovered from SHACL links.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct ShapeProperty {
+    name: String,
+    predicate: String,
+    is_collection: bool,
+    is_flag: bool,
+    is_required: bool,
+    initial_value: Option<String>,
+    resolve_language: Option<String>,
+    datatype: Option<String>,
+}
+
+/// A model shape reconstructed from SHACL links in the store.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct ModelShape {
+    target_class: String,
+    #[allow(dead_code)]
+    shape_uri: String,
+    properties: Vec<ShapeProperty>,
+}
+
+// ---------------------------------------------------------------------------
+// literal: URI parsing (typed)
+// ---------------------------------------------------------------------------
+
+/// Parse a `literal:` URI into a typed JSON value.
+/// Returns the raw string as Value::String if not a literal: URI.
+fn parse_literal_value(uri: &str) -> Value {
+    let body = if let Some(rest) = uri.strip_prefix("literal:") {
+        rest
+    } else {
+        return Value::String(uri.to_string());
+    };
+
+    if let Some(rest) = body.strip_prefix("string:") {
+        let decoded = urlencoding::decode(rest).unwrap_or_else(|_| rest.into());
+        // Check if it's a signed expression JSON
+        if let Ok(json_val) = serde_json::from_str::<Value>(&decoded) {
+            if let Some(data) = json_val.get("data") {
+                return match data {
+                    Value::String(s) => Value::String(s.clone()),
+                    _ => data.clone(),
+                };
+            }
+        }
+        Value::String(decoded.into_owned())
+    } else if let Some(rest) = body.strip_prefix("number:") {
+        if let Ok(n) = rest.parse::<i64>() {
+            Value::Number(n.into())
+        } else if let Ok(f) = rest.parse::<f64>() {
+            serde_json::Number::from_f64(f)
+                .map(Value::Number)
+                .unwrap_or(Value::String(rest.to_string()))
+        } else {
+            Value::String(rest.to_string())
+        }
+    } else if let Some(rest) = body.strip_prefix("boolean:") {
+        match rest {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => Value::String(rest.to_string()),
+        }
+    } else if let Some(rest) = body.strip_prefix("json:") {
+        let decoded = urlencoding::decode(rest).unwrap_or_else(|_| rest.into());
+        if let Ok(json_val) = serde_json::from_str::<Value>(&decoded) {
+            if let Some(data) = json_val.get("data") {
+                return match data {
+                    Value::String(s) => Value::String(s.clone()),
+                    _ => data.clone(),
+                };
+            }
+            json_val
+        } else {
+            Value::String(decoded.into_owned())
+        }
+    } else {
+        Value::String(uri.to_string())
+    }
+}
+
+/// Extract numeric value from a JSON value for comparison.
+fn to_f64(val: &Value) -> Option<f64> {
+    match val {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shape loading from SHACL links
+// ---------------------------------------------------------------------------
+
+/// Load a model shape from the SHACL links stored in the Oxigraph store.
+///
+/// The SHACL links follow this pattern (set up by `parse_shacl_to_links`):
+/// - `<namespace://ClassNameShape> sh://property <namespace://ClassName.propName>`
+/// - `<namespace://ClassName.propName> sh://path <predicate_uri>`
+/// - `<namespace://ClassName.propName> rdf://type sh://PropertyShape | ad4m://CollectionShape`
+/// - `<namespace://ClassName.propName> sh://datatype <xsd://...>`
+/// - `<namespace://ClassName.propName> sh://minCount literal:1^^xsd:integer`
+/// - etc.
+fn load_shape(store: &SparqlStore, class_name: &str) -> Result<ModelShape, Error> {
+    // Step 1: Find the shape URI and target class via SPARQL
+    let query = format!(
+        r#"
+        SELECT ?shapeUri ?targetClass WHERE {{
+            ?targetClass <rdf://type> <ad4m://SubjectClass> .
+            ?targetClass <ad4m://shape> ?shapeUri .
+            FILTER(STRENDS(STR(?targetClass), "{class_name}"))
+        }}
+        LIMIT 1
+        "#
+    );
+
+    let result_json = store.query(&query)?;
+    let results: Vec<Value> = serde_json::from_str(&result_json)?;
+
+    if results.is_empty() {
+        return Err(anyhow!(
+            "No SHACL shape found for class '{}'. Ensure the class has been registered with addSdna().",
+            class_name
+        ));
+    }
+
+    let shape_uri = results[0]["shapeUri"]
+        .as_str()
+        .ok_or_else(|| anyhow!("Missing shapeUri in SHACL query result"))?
+        .to_string();
+    let target_class = results[0]["targetClass"]
+        .as_str()
+        .ok_or_else(|| anyhow!("Missing targetClass in SHACL query result"))?
+        .to_string();
+
+    // Step 2: Load all property shapes for this shape
+    let props_query = format!(
+        r#"
+        SELECT ?propUri ?path ?propType ?datatype ?minCount ?maxCount ?resolveLanguage WHERE {{
+            <{shape_uri}> <sh://property> ?propUri .
+            ?propUri <sh://path> ?path .
+            ?propUri <rdf://type> ?propType .
+            OPTIONAL {{ ?propUri <sh://datatype> ?datatype . }}
+            OPTIONAL {{ ?propUri <sh://minCount> ?minCount . }}
+            OPTIONAL {{ ?propUri <sh://maxCount> ?maxCount . }}
+            OPTIONAL {{ ?propUri <ad4m://resolveLanguage> ?resolveLanguage . }}
+        }}
+        "#
+    );
+
+    let props_json = store.query(&props_query)?;
+    let prop_results: Vec<Value> = serde_json::from_str(&props_json)?;
+
+    let mut properties = Vec::new();
+
+    for prop_row in &prop_results {
+        let prop_uri = prop_row["propUri"].as_str().unwrap_or("");
+        let path = prop_row["path"].as_str().unwrap_or("").to_string();
+        let prop_type = prop_row["propType"].as_str().unwrap_or("");
+        let datatype = prop_row["datatype"].as_str().map(|s| s.to_string());
+        let min_count_str = prop_row["minCount"].as_str().unwrap_or("0");
+        let resolve_language = prop_row["resolveLanguage"].as_str().map(|s| {
+            // Decode if it's a literal: URI
+            if let Some(rest) = s.strip_prefix("literal:string:") {
+                urlencoding::decode(rest)
+                    .unwrap_or_else(|_| rest.into())
+                    .into_owned()
+            } else {
+                s.to_string()
+            }
+        });
+
+        // Extract name from prop_uri: "namespace://ClassName.propName" -> "propName"
+        let name = prop_uri
+            .rsplit_once('.')
+            .map(|(_, n)| n.to_string())
+            .unwrap_or_else(|| {
+                // Fallback: extract from path
+                path.rsplit(&['/', '#', ':'][..])
+                    .next()
+                    .unwrap_or("unknown")
+                    .to_string()
+            });
+
+        let is_collection = prop_type == "ad4m://CollectionShape";
+
+        // Parse minCount to detect required
+        let min_count: u32 = min_count_str
+            .strip_prefix("literal:")
+            .and_then(|s| s.split("^^").next())
+            .unwrap_or(min_count_str)
+            .parse()
+            .unwrap_or(0);
+
+        // Check if this is a flag property by looking for an initial value
+        // Flags have a specific target value in the conformance check
+        let initial_value = get_initial_value(store, prop_uri, &path, &target_class)?;
+        let is_flag = initial_value.is_some() && min_count > 0;
+
+        properties.push(ShapeProperty {
+            name,
+            predicate: path,
+            is_collection,
+            is_flag,
+            is_required: min_count > 0,
+            initial_value,
+            resolve_language,
+            datatype,
+        });
+    }
+
+    Ok(ModelShape {
+        target_class,
+        shape_uri,
+        properties,
+    })
+}
+
+/// Check if a property has an initial/flag value by looking at the constructor actions
+/// or at the initial value link pattern.
+fn get_initial_value(
+    store: &SparqlStore,
+    _prop_uri: &str,
+    predicate: &str,
+    target_class: &str,
+) -> Result<Option<String>, Error> {
+    // Look for constructor actions that set an initial value for this predicate
+    // Constructor links: <ShapeUri> ad4m://constructor <literal:string:JSON>
+    // The JSON contains actions like {"action": "addLink", "source": "this", "predicate": "...", "target": "..."}
+
+    // Also check if there's an existing flag-like pattern: a conformance check that expects
+    // a specific target value for this predicate
+    // For now, we check if there are instances where this predicate points to a fixed URI (not a literal:)
+    // This is a simplified heuristic — the TS side uses decorator metadata (initial, flag) which
+    // we'll receive directly from the client in the query
+
+    // Quick check: is there a link from targetClass with this predicate to a fixed value?
+    // Look for the "required" flag property pattern
+    let query = format!(
+        r#"
+        SELECT ?target WHERE {{
+            <{}> <{}> ?target .
+        }}
+        LIMIT 1
+        "#,
+        target_class, predicate
+    );
+
+    let result_json = store.query(&query).unwrap_or_else(|_| "[]".to_string());
+    let results: Vec<Value> = serde_json::from_str(&result_json).unwrap_or_default();
+
+    // If the target_class itself has a link with this predicate, it might be a flag/initial value
+    // But this is heuristic — the definitive source is the TS metadata sent with the query
+    // For now return None and let the client send shape metadata
+    let _ = results;
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// Core query execution
+// ---------------------------------------------------------------------------
+
+/// Execute a model query against the Oxigraph store.
+///
+/// This is the main entry point that replaces the TS SPARQL-build → hydrate → filter pipeline.
+pub fn execute_model_query(
+    store: &SparqlStore,
+    class_name: &str,
+    query_input: &ModelQueryInput,
+    shape_json: Option<&str>,
+) -> Result<ModelQueryResult, Error> {
+    // Load shape from store or parse from provided JSON
+    let shape = if let Some(json) = shape_json {
+        parse_shape_from_json(json, class_name)?
+    } else {
+        load_shape(store, class_name)?
+    };
+
+    // Build SPARQL to find conforming instances and their property values
+    let sparql = build_instance_sparql(&shape, query_input);
+
+    // Execute the SPARQL query
+    let result_json = store.query(&sparql)?;
+    let raw_results: Vec<Value> = serde_json::from_str(&result_json)?;
+
+    // Group results by source (each instance may have multiple rows)
+    let grouped = group_results_by_source(&raw_results, &shape);
+
+    // Hydrate instances from grouped results
+    let mut instances = hydrate_instances(&shape, &grouped);
+
+    // Apply where-clause filters
+    if let Some(ref where_clause) = query_input.where_clause {
+        instances.retain(|inst| matches_where(inst, where_clause));
+    }
+
+    // Calculate total count before pagination
+    let total_count = instances.len();
+
+    // Apply ordering
+    if let Some(ref order) = query_input.order {
+        sort_instances(&mut instances, order);
+    } else if query_input.limit.is_some() || query_input.offset.is_some() {
+        // Default: order by timestamp ASC when paginating
+        sort_instances(
+            &mut instances,
+            &[("timestamp".to_string(), OrderDirection::ASC)],
+        );
+    }
+
+    // Apply pagination
+    let offset = query_input.offset.unwrap_or(0);
+    let paginated: Vec<Value> = if let Some(limit) = query_input.limit {
+        instances.into_iter().skip(offset).take(limit).collect()
+    } else {
+        instances.into_iter().skip(offset).collect()
+    };
+
+    // Strip unrequested properties if specified
+    let final_instances = if let Some(ref requested) = query_input.properties {
+        paginated
+            .into_iter()
+            .map(|inst| filter_properties(inst, requested))
+            .collect()
+    } else {
+        paginated
+    };
+
+    Ok(ModelQueryResult {
+        instances: final_instances,
+        total_count,
+    })
+}
+
+/// Parse shape metadata from JSON sent by the TS client.
+/// This is more reliable than reading from the store because the TS client
+/// has the definitive decorator metadata (flags, required, initial values, etc.).
+fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Error> {
+    let meta: Value =
+        serde_json::from_str(json).map_err(|e| anyhow!("Failed to parse shape JSON: {}", e))?;
+
+    let target_class = meta["className"]
+        .as_str()
+        .unwrap_or(class_name)
+        .to_string();
+
+    let mut properties = Vec::new();
+
+    // Parse properties from the metadata
+    if let Some(props) = meta["properties"].as_object() {
+        for (name, prop_meta) in props {
+            let predicate = prop_meta["predicate"].as_str().unwrap_or("").to_string();
+            if predicate.is_empty() {
+                continue;
+            }
+
+            let is_required = prop_meta["required"].as_bool().unwrap_or(false);
+            let is_flag = prop_meta["flag"].as_bool().unwrap_or(false);
+            let initial = prop_meta["initial"].as_str().map(|s| s.to_string());
+            let resolve_language = prop_meta["resolveLanguage"].as_str().map(|s| s.to_string());
+            let datatype = prop_meta["datatype"].as_str().map(|s| s.to_string());
+
+            properties.push(ShapeProperty {
+                name: name.clone(),
+                predicate,
+                is_collection: false,
+                is_flag,
+                is_required,
+                initial_value: initial,
+                resolve_language,
+                datatype,
+            });
+        }
+    }
+
+    // Parse relations from the metadata
+    if let Some(rels) = meta["relations"].as_object() {
+        for (name, rel_meta) in rels {
+            let predicate = rel_meta["predicate"].as_str().unwrap_or("").to_string();
+            if predicate.is_empty() {
+                continue;
+            }
+
+            properties.push(ShapeProperty {
+                name: name.clone(),
+                predicate,
+                is_collection: true,
+                is_flag: false,
+                is_required: false,
+                initial_value: None,
+                resolve_language: None,
+                datatype: None,
+            });
+        }
+    }
+
+    // Build a shape URI from the className
+    let shape_uri = format!("{}Shape", target_class);
+
+    Ok(ModelShape {
+        target_class,
+        shape_uri,
+        properties,
+    })
+}
+
+/// Build the SPARQL query that finds all conforming instances and their link data.
+///
+/// The query pattern:
+/// 1. Conformance: JOIN on required/flag properties to identify valid instances
+/// 2. Data retrieval: Fetch all links for conforming instances with reifier metadata
+fn build_instance_sparql(shape: &ModelShape, query: &ModelQueryInput) -> String {
+    let mut conformance_patterns = Vec::new();
+
+    // Parent filter
+    if let Some(ref parent) = query.parent {
+        match parent {
+            ParentScope::Raw { id, predicate } => {
+                conformance_patterns
+                    .push(format!("    <{}> <{}> ?source .", id, predicate));
+            }
+            ParentScope::Model { id, field, model } => {
+                // For model-based parent scope, we need to resolve the predicate
+                // The client should send the resolved predicate, but we handle both forms
+                if let Some(ref f) = field {
+                    conformance_patterns
+                        .push(format!("    <{}> <{}> ?source .", id, f));
+                } else {
+                    // Fallback: use model name as predicate hint
+                    conformance_patterns
+                        .push(format!("    <{}> ?_parentPred ?source .", id));
+                    conformance_patterns.push(format!(
+                        "    FILTER(STRENDS(STR(?_parentPred), \"{}\"))",
+                        model
+                    ));
+                }
+            }
+        }
+    }
+
+    // Conformance patterns from shape properties
+    let mut has_conformance = false;
+    for prop in &shape.properties {
+        if prop.is_required {
+            has_conformance = true;
+            if prop.is_flag {
+                if let Some(ref initial) = prop.initial_value {
+                    conformance_patterns
+                        .push(format!("    ?source <{}> <{}> .", prop.predicate, initial));
+                } else {
+                    conformance_patterns.push(format!(
+                        "    ?source <{}> ?cf_{} .",
+                        prop.predicate, prop.name
+                    ));
+                }
+            } else {
+                conformance_patterns.push(format!(
+                    "    ?source <{}> ?cf_{} .",
+                    prop.predicate, prop.name
+                ));
+            }
+        }
+    }
+
+    // Fallback: if no required properties, try initial values
+    if !has_conformance {
+        for prop in &shape.properties {
+            if let Some(ref initial) = prop.initial_value {
+                has_conformance = true;
+                if prop.is_flag {
+                    conformance_patterns
+                        .push(format!("    ?source <{}> <{}> .", prop.predicate, initial));
+                } else {
+                    conformance_patterns.push(format!(
+                        "    ?source <{}> ?cfInit_{} .",
+                        prop.predicate, prop.name
+                    ));
+                }
+                break;
+            }
+        }
+    }
+
+    // Fallback: structural matching using known predicates
+    if !has_conformance && conformance_patterns.is_empty() {
+        let known_predicates: Vec<String> = shape
+            .properties
+            .iter()
+            .filter(|p| !p.predicate.is_empty())
+            .map(|p| format!("<{}>", p.predicate))
+            .collect();
+
+        if !known_predicates.is_empty() {
+            conformance_patterns.push(format!(
+                "    {{ SELECT DISTINCT ?source WHERE {{ ?source ?_structPred ?_structTarget . FILTER(?_structPred IN ({})) }} }}",
+                known_predicates.join(", ")
+            ));
+        }
+    }
+
+    // WHERE clause filters that can be pushed to SPARQL (equality, IN)
+    let mut where_patterns = Vec::new();
+    if let Some(ref wc) = query.where_clause {
+        for (prop_name, condition) in wc {
+            if prop_name == "base" || prop_name == "id" {
+                // Filter by base expression URI directly
+                if let WhereCondition::String(val) = condition {
+                    where_patterns.push(format!(
+                        "    FILTER(?source = <{}>)",
+                        val
+                    ));
+                }
+                continue;
+            }
+            // Skip author/timestamp — handled post-hydration
+            if prop_name == "author" || prop_name == "timestamp" || prop_name == "createdAt" || prop_name == "updatedAt" {
+                continue;
+            }
+
+            // Find the property metadata
+            if let Some(prop) = shape.properties.iter().find(|p| &p.name == prop_name) {
+                // Only push simple equality to SPARQL
+                match condition {
+                    WhereCondition::String(val) => {
+                        let iri_val = value_to_literal_iri_string(val);
+                        where_patterns.push(format!(
+                            "    ?source <{}> <{}> .",
+                            prop.predicate, iri_val
+                        ));
+                    }
+                    WhereCondition::Bool(val) => {
+                        let iri_val = format!("literal:boolean:{}", val);
+                        where_patterns.push(format!(
+                            "    ?source <{}> <{}> .",
+                            prop.predicate, iri_val
+                        ));
+                    }
+                    _ => {
+                        // Complex conditions (comparison ops, arrays, etc.) handled post-hydration
+                    }
+                }
+            }
+        }
+    }
+
+    let conformance = conformance_patterns.join("\n");
+    let where_extra = where_patterns.join("\n");
+
+    format!(
+        r#"SELECT ?source ?predicate ?target ?author ?timestamp WHERE {{
+{conformance}
+{where_extra}
+    ?source ?predicate ?target .
+    ?_reifier <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( ?source ?predicate ?target )>> .
+    FILTER(isIRI(?source) && isIRI(?predicate))
+    ?_reifier <ad4m://ontology/author> ?author .
+    ?_reifier <ad4m://ontology/timestamp> ?timestamp .
+}}"#
+    )
+}
+
+/// Convert a JS value to its literal: IRI form, matching how the Rust executor
+/// stores property values.
+fn value_to_literal_iri_string(s: &str) -> String {
+    // If it already looks like a URI, use as-is
+    if s.contains("://") || s.starts_with("literal:") {
+        return s.to_string();
+    }
+    // Wrap as literal:string:
+    format!("literal:string:{}", urlencoding::encode(s))
+}
+
+// ---------------------------------------------------------------------------
+// Result grouping
+// ---------------------------------------------------------------------------
+
+/// An intermediate representation of all links belonging to one instance.
+#[derive(Debug)]
+struct InstanceLinks {
+    source: String,
+    /// (predicate, target, author, timestamp) for each link
+    links: Vec<(String, String, String, String)>,
+}
+
+/// Group SPARQL result rows by `?source` to collect all links per instance.
+fn group_results_by_source(rows: &[Value], _shape: &ModelShape) -> Vec<InstanceLinks> {
+    let mut map: BTreeMap<String, Vec<(String, String, String, String)>> = BTreeMap::new();
+
+    for row in rows {
+        let source = match row["source"].as_str() {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let predicate = row["predicate"].as_str().unwrap_or("").to_string();
+        let target = row["target"].as_str().unwrap_or("").to_string();
+        let author = row["author"].as_str().unwrap_or("").to_string();
+        let timestamp = row["timestamp"].as_str().unwrap_or("").to_string();
+
+        map.entry(source)
+            .or_default()
+            .push((predicate, target, author, timestamp));
+    }
+
+    map.into_iter()
+        .map(|(source, links)| InstanceLinks { source, links })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Hydration
+// ---------------------------------------------------------------------------
+
+/// Hydrate instances from grouped link data.
+///
+/// Mirrors the TS `hydrateFromLinks()` logic:
+/// - Single-valued properties: latest-wins (by timestamp)
+/// - Collections: chronological order, all values
+/// - Metadata: author = earliest link author, timestamp = earliest
+fn hydrate_instances(shape: &ModelShape, grouped: &[InstanceLinks]) -> Vec<Value> {
+    grouped
+        .iter()
+        .filter_map(|inst_links| hydrate_one(shape, inst_links))
+        .collect()
+}
+
+/// Hydrate a single instance from its links.
+fn hydrate_one(shape: &ModelShape, inst: &InstanceLinks) -> Option<Value> {
+    let mut obj = Map::new();
+
+    // Set base expression / id
+    obj.insert("id".to_string(), Value::String(inst.source.clone()));
+    obj.insert(
+        "baseExpression".to_string(),
+        Value::String(inst.source.clone()),
+    );
+
+    // Build a predicate -> property map for fast lookup
+    let pred_to_prop: HashMap<&str, &ShapeProperty> = shape
+        .properties
+        .iter()
+        .map(|p| (p.predicate.as_str(), p))
+        .collect();
+
+    // Track latest timestamp per property for latest-wins
+    let mut prop_timestamps: HashMap<&str, &str> = HashMap::new();
+    // Track collection values
+    let mut collection_values: HashMap<&str, Vec<(&str, &str)>> = HashMap::new();
+    // Track overall earliest timestamp and its author
+    let mut earliest_timestamp: Option<&str> = None;
+    let mut earliest_author: Option<&str> = None;
+    let mut latest_timestamp: Option<&str> = None;
+
+    // First pass: categorize links
+    for (predicate, target, author, timestamp) in &inst.links {
+        // Update instance-level timestamps
+        let ts = timestamp.as_str();
+        match earliest_timestamp {
+            None => {
+                earliest_timestamp = Some(ts);
+                earliest_author = Some(author.as_str());
+            }
+            Some(et) if ts < et => {
+                earliest_timestamp = Some(ts);
+                earliest_author = Some(author.as_str());
+            }
+            _ => {}
+        }
+        match latest_timestamp {
+            None => {
+                latest_timestamp = Some(ts);
+            }
+            Some(lt) if ts > lt => {
+                latest_timestamp = Some(ts);
+            }
+            _ => {}
+        }
+
+        if let Some(prop) = pred_to_prop.get(predicate.as_str()) {
+            if prop.is_collection {
+                // Collections: accumulate all values with timestamps
+                collection_values
+                    .entry(prop.name.as_str())
+                    .or_default()
+                    .push((target.as_str(), ts));
+            } else if prop.is_flag {
+                // Flags: just note presence (value is the target URI)
+                // Skip setting — flags are conformance-only
+                // But if it's also a regular property, set it
+                let current_ts = prop_timestamps.get(prop.name.as_str()).copied();
+                if current_ts.is_none() || current_ts.map(|t| ts > t).unwrap_or(true) {
+                    prop_timestamps.insert(prop.name.as_str(), ts);
+                    // Parse the target value
+                    let val = parse_literal_value(target);
+                    obj.insert(prop.name.clone(), val);
+                }
+            } else {
+                // Single-valued: latest-wins
+                let current_ts = prop_timestamps.get(prop.name.as_str()).copied();
+                if current_ts.is_none() || current_ts.map(|t| ts > t).unwrap_or(true) {
+                    prop_timestamps.insert(prop.name.as_str(), ts);
+                    let val = parse_literal_value(target);
+                    obj.insert(prop.name.clone(), val);
+                }
+            }
+        }
+        // Links with unknown predicates are ignored (they belong to other shapes or metadata)
+    }
+
+    // Set collection properties
+    for (name, mut values) in collection_values {
+        // Sort by timestamp (chronological)
+        values.sort_by_key(|&(_, ts)| ts);
+        let arr: Vec<Value> = values
+            .iter()
+            .map(|&(target, _)| {
+                // For collections, the target is typically a URI (relation ID)
+                // not a literal: value
+                if target.starts_with("literal:") {
+                    parse_literal_value(target)
+                } else {
+                    Value::String(target.to_string())
+                }
+            })
+            .collect();
+        obj.insert(name.to_string(), Value::Array(arr));
+    }
+
+    // Set metadata
+    if let Some(ts) = earliest_timestamp {
+        obj.insert("createdAt".to_string(), Value::String(ts.to_string()));
+    }
+    if let Some(ts) = latest_timestamp {
+        obj.insert("updatedAt".to_string(), Value::String(ts.to_string()));
+    }
+    if let Some(author) = earliest_author {
+        obj.insert("author".to_string(), Value::String(author.to_string()));
+    }
+
+    // Set timestamp as ISO string (used by ordering)
+    if let Some(ts) = earliest_timestamp {
+        obj.insert("timestamp".to_string(), Value::String(ts.to_string()));
+    }
+
+    Some(Value::Object(obj))
+}
+
+// ---------------------------------------------------------------------------
+// Where-clause filtering
+// ---------------------------------------------------------------------------
+
+/// Check if an instance matches all where-clause conditions.
+fn matches_where(instance: &Value, where_clause: &HashMap<String, WhereCondition>) -> bool {
+    for (prop_name, condition) in where_clause {
+        if prop_name == "base" || prop_name == "id" {
+            // Already filtered in SPARQL
+            continue;
+        }
+
+        let val = &instance[prop_name];
+        if !matches_condition(val, condition) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Check if a single value matches a where condition.
+fn matches_condition(val: &Value, condition: &WhereCondition) -> bool {
+    match condition {
+        WhereCondition::String(expected) => match val {
+            Value::String(s) => s == expected,
+            Value::Null => false,
+            _ => val.to_string().trim_matches('"') == expected.as_str(),
+        },
+        WhereCondition::Number(expected) => {
+            to_f64(val).map(|v| (v - expected).abs() < f64::EPSILON) == Some(true)
+        }
+        WhereCondition::Bool(expected) => val.as_bool() == Some(*expected),
+        WhereCondition::StringArray(expected) => {
+            // IN operator: value must be in the array
+            match val {
+                Value::String(s) => expected.contains(s),
+                _ => {
+                    let s = val.to_string().trim_matches('"').to_string();
+                    expected.contains(&s)
+                }
+            }
+        }
+        WhereCondition::NumberArray(expected) => {
+            if let Some(v) = to_f64(val) {
+                expected.iter().any(|e| (v - e).abs() < f64::EPSILON)
+            } else {
+                false
+            }
+        }
+        WhereCondition::Ops(ops) => matches_ops(val, ops),
+    }
+}
+
+/// Check if a value matches operator conditions.
+fn matches_ops(val: &Value, ops: &WhereOps) -> bool {
+    // NOT
+    if let Some(ref not_val) = ops.not {
+        match not_val {
+            Value::String(s) => {
+                if let Value::String(v) = val {
+                    if v == s {
+                        return false;
+                    }
+                }
+            }
+            Value::Number(n) => {
+                if let Some(v) = to_f64(val) {
+                    if let Some(e) = n.as_f64() {
+                        if (v - e).abs() < f64::EPSILON {
+                            return false;
+                        }
+                    }
+                }
+            }
+            Value::Bool(b) => {
+                if val.as_bool() == Some(*b) {
+                    return false;
+                }
+            }
+            Value::Array(arr) => {
+                // NOT IN: value must NOT be in the array
+                for item in arr {
+                    if match (val, item) {
+                        (Value::String(v), Value::String(s)) => v == s,
+                        (Value::Number(_), Value::Number(_)) => {
+                            to_f64(val)
+                                .zip(item.as_f64())
+                                .map(|(a, b)| (a - b).abs() < f64::EPSILON)
+                                .unwrap_or(false)
+                        }
+                        _ => false,
+                    } {
+                        return false;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Numeric comparisons
+    if let Some(v) = to_f64(val) {
+        if let Some(lt) = ops.lt {
+            if v >= lt {
+                return false;
+            }
+        }
+        if let Some(lte) = ops.lte {
+            if v > lte {
+                return false;
+            }
+        }
+        if let Some(gt) = ops.gt {
+            if v <= gt {
+                return false;
+            }
+        }
+        if let Some(gte) = ops.gte {
+            if v < gte {
+                return false;
+            }
+        }
+        if let Some((lo, hi)) = ops.between {
+            if v < lo || v > hi {
+                return false;
+            }
+        }
+    } else {
+        // For string comparisons, use lexicographic comparison
+        if let Value::String(s) = val {
+            // Try parsing as timestamp for comparison
+            if let Some(lt) = ops.lt {
+                if let Ok(sv) = s.parse::<f64>() {
+                    if sv >= lt {
+                        return false;
+                    }
+                }
+            }
+            if let Some(lte) = ops.lte {
+                if let Ok(sv) = s.parse::<f64>() {
+                    if sv > lte {
+                        return false;
+                    }
+                }
+            }
+            if let Some(gt) = ops.gt {
+                if let Ok(sv) = s.parse::<f64>() {
+                    if sv <= gt {
+                        return false;
+                    }
+                }
+            }
+            if let Some(gte) = ops.gte {
+                if let Ok(sv) = s.parse::<f64>() {
+                    if sv < gte {
+                        return false;
+                    }
+                }
+            }
+            if let Some((lo, hi)) = ops.between {
+                if let Ok(sv) = s.parse::<f64>() {
+                    if sv < lo || sv > hi {
+                        return false;
+                    }
+                }
+            }
+        }
+        // If value is null and we have numeric conditions, don't match
+        if val.is_null() {
+            if ops.lt.is_some()
+                || ops.lte.is_some()
+                || ops.gt.is_some()
+                || ops.gte.is_some()
+                || ops.between.is_some()
+            {
+                return false;
+            }
+        }
+    }
+
+    // Contains
+    if let Some(ref contains_val) = ops.contains {
+        match val {
+            Value::String(s) => {
+                let needle = match contains_val {
+                    Value::String(cs) => cs.clone(),
+                    _ => contains_val.to_string(),
+                };
+                if !s.to_lowercase().contains(&needle.to_lowercase()) {
+                    return false;
+                }
+            }
+            Value::Array(arr) => {
+                let found = arr.iter().any(|item| match (item, contains_val) {
+                    (Value::String(a), Value::String(b)) => a == b,
+                    (Value::Number(_), Value::Number(_)) => item == contains_val,
+                    _ => false,
+                });
+                if !found {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+/// Sort instances by the given order specification.
+fn sort_instances(instances: &mut [Value], order: &[(String, OrderDirection)]) {
+    instances.sort_by(|a, b| {
+        for (prop, dir) in order {
+            let av = &a[prop];
+            let bv = &b[prop];
+
+            let cmp = compare_values(av, bv);
+
+            if cmp != Ordering::Equal {
+                return if *dir == OrderDirection::DESC {
+                    cmp.reverse()
+                } else {
+                    cmp
+                };
+            }
+        }
+        Ordering::Equal
+    });
+}
+
+/// Compare two JSON values with type-aware logic.
+fn compare_values(a: &Value, b: &Value) -> Ordering {
+    // Handle nulls — push to end
+    match (a.is_null(), b.is_null()) {
+        (true, true) => return Ordering::Equal,
+        (true, false) => return Ordering::Greater,
+        (false, true) => return Ordering::Less,
+        _ => {}
+    }
+
+    // Try numeric comparison first
+    if let (Some(an), Some(bn)) = (to_f64(a), to_f64(b)) {
+        return an
+            .partial_cmp(&bn)
+            .unwrap_or(Ordering::Equal);
+    }
+
+    // String comparison
+    let as_str = match a {
+        Value::String(s) => s.clone(),
+        _ => a.to_string(),
+    };
+    let bs_str = match b {
+        Value::String(s) => s.clone(),
+        _ => b.to_string(),
+    };
+
+    as_str.cmp(&bs_str)
+}
+
+// ---------------------------------------------------------------------------
+// Property filtering (sparse fieldset)
+// ---------------------------------------------------------------------------
+
+/// Filter an instance to only include requested properties.
+fn filter_properties(instance: Value, requested: &[String]) -> Value {
+    if let Value::Object(mut obj) = instance {
+        let always_keep = ["id", "baseExpression"];
+        let keys: Vec<String> = obj.keys().cloned().collect();
+        for key in keys {
+            if always_keep.contains(&key.as_str()) {
+                continue;
+            }
+            if !requested.iter().any(|r| r == &key) {
+                obj.remove(&key);
+            }
+        }
+        Value::Object(obj)
+    } else {
+        instance
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reverse relation resolution (Phase 2)
+// ---------------------------------------------------------------------------
+
+/// Resolve reverse relations (BelongsToOne/BelongsToMany) for all instances in batch.
+pub fn resolve_reverse_relations(
+    store: &SparqlStore,
+    instances: &mut [Value],
+    relations: &[(String, String, bool)], // (name, predicate, is_single)
+) -> Result<(), Error> {
+    if relations.is_empty() || instances.is_empty() {
+        return Ok(());
+    }
+
+    for (rel_name, predicate, is_single) in relations {
+        // Batch query: find all links with this predicate pointing to any of our instances
+        for inst in instances.iter_mut() {
+            let id = match inst["id"].as_str() {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+
+            let links = store.query_links(None, Some(predicate), Some(&id), None, None, None)?;
+
+            let source_ids: Vec<Value> = links
+                .iter()
+                .map(|l| Value::String(l.data.source.clone()))
+                .collect();
+
+            if *is_single {
+                let val = source_ids.last().cloned().unwrap_or(Value::Null);
+                inst.as_object_mut()
+                    .map(|obj| obj.insert(rel_name.clone(), val));
+            } else {
+                inst.as_object_mut()
+                    .map(|obj| obj.insert(rel_name.clone(), Value::Array(source_ids)));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Include (eager-loading) support (Phase 2)
+// ---------------------------------------------------------------------------
+
+/// Eager-load included relations for all instances.
+pub(crate) fn resolve_includes(
+    store: &SparqlStore,
+    instances: &mut [Value],
+    include: &HashMap<String, IncludeValue>,
+    shape: &ModelShape,
+) -> Result<(), Error> {
+    for (rel_name, include_val) in include {
+        // Find the relation property in the shape
+        let prop = match shape.properties.iter().find(|p| &p.name == rel_name) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        if !prop.is_collection {
+            continue; // Only collections can be eagerly loaded
+        }
+
+        let sub_query = match include_val {
+            IncludeValue::Bool(false) => continue,
+            IncludeValue::Bool(true) => ModelQueryInput::default(),
+            IncludeValue::SubQuery(sq) => *sq.clone(),
+        };
+
+        // For each instance, find related entities
+        for inst in instances.iter_mut() {
+            let id = match inst["id"].as_str() {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+
+            // Forward relation: source=instance, predicate=rel.predicate, target=?
+            let related_links =
+                store.query_links(Some(&id), Some(&prop.predicate), None, None, None, None)?;
+
+            let related_ids: Vec<String> =
+                related_links.iter().map(|l| l.data.target.clone()).collect();
+
+            // If there's a sub-query with its own class, we'd need to recursively query
+            // For now, just set the IDs
+            let arr: Vec<Value> = related_ids.into_iter().map(Value::String).collect();
+
+            inst.as_object_mut()
+                .map(|obj| obj.insert(rel_name.clone(), Value::Array(arr)));
+        }
+
+        let _ = sub_query; // Will be used for nested querying in future
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_parse_literal_value_string() {
+        assert_eq!(
+            parse_literal_value("literal:string:hello%20world"),
+            Value::String("hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_literal_value_number() {
+        assert_eq!(
+            parse_literal_value("literal:number:42"),
+            Value::Number(42.into())
+        );
+        assert_eq!(
+            parse_literal_value("literal:number:3.14"),
+            serde_json::Number::from_f64(3.14)
+                .map(Value::Number)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_parse_literal_value_boolean() {
+        assert_eq!(
+            parse_literal_value("literal:boolean:true"),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            parse_literal_value("literal:boolean:false"),
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn test_parse_literal_value_non_literal() {
+        assert_eq!(
+            parse_literal_value("recipe://Recipe"),
+            Value::String("recipe://Recipe".to_string())
+        );
+    }
+
+    #[test]
+    fn test_matches_condition_string() {
+        let val = Value::String("hello".to_string());
+        assert!(matches_condition(
+            &val,
+            &WhereCondition::String("hello".to_string())
+        ));
+        assert!(!matches_condition(
+            &val,
+            &WhereCondition::String("world".to_string())
+        ));
+    }
+
+    #[test]
+    fn test_matches_condition_number() {
+        let val = Value::Number(42.into());
+        assert!(matches_condition(&val, &WhereCondition::Number(42.0)));
+        assert!(!matches_condition(&val, &WhereCondition::Number(43.0)));
+    }
+
+    #[test]
+    fn test_matches_ops_gt_lt() {
+        let val = Value::Number(5.into());
+        assert!(matches_ops(
+            &val,
+            &WhereOps {
+                gt: Some(3.0),
+                lt: Some(10.0),
+                ..Default::default()
+            }
+        ));
+        assert!(!matches_ops(
+            &val,
+            &WhereOps {
+                gt: Some(5.0),
+                ..Default::default()
+            }
+        ));
+    }
+
+    #[test]
+    fn test_matches_ops_between() {
+        let val = Value::Number(5.into());
+        assert!(matches_ops(
+            &val,
+            &WhereOps {
+                between: Some((1.0, 10.0)),
+                ..Default::default()
+            }
+        ));
+        assert!(!matches_ops(
+            &val,
+            &WhereOps {
+                between: Some((6.0, 10.0)),
+                ..Default::default()
+            }
+        ));
+    }
+
+    #[test]
+    fn test_matches_ops_contains() {
+        let val = Value::String("hello world".to_string());
+        assert!(matches_ops(
+            &val,
+            &WhereOps {
+                contains: Some(Value::String("world".to_string())),
+                ..Default::default()
+            }
+        ));
+        assert!(!matches_ops(
+            &val,
+            &WhereOps {
+                contains: Some(Value::String("xyz".to_string())),
+                ..Default::default()
+            }
+        ));
+    }
+
+    #[test]
+    fn test_matches_ops_not() {
+        let val = Value::String("hello".to_string());
+        assert!(matches_ops(
+            &val,
+            &WhereOps {
+                not: Some(Value::String("world".to_string())),
+                ..Default::default()
+            }
+        ));
+        assert!(!matches_ops(
+            &val,
+            &WhereOps {
+                not: Some(Value::String("hello".to_string())),
+                ..Default::default()
+            }
+        ));
+    }
+
+    #[test]
+    fn test_compare_values_numeric() {
+        assert_eq!(
+            compare_values(&Value::Number(1.into()), &Value::Number(2.into())),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_values(&Value::Number(2.into()), &Value::Number(1.into())),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn test_compare_values_null() {
+        assert_eq!(
+            compare_values(&Value::Null, &Value::Number(1.into())),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_values(&Value::Number(1.into()), &Value::Null),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn test_sort_instances() {
+        let mut instances = vec![
+            json!({"name": "C", "age": 30}),
+            json!({"name": "A", "age": 10}),
+            json!({"name": "B", "age": 20}),
+        ];
+        sort_instances(
+            &mut instances,
+            &[("age".to_string(), OrderDirection::ASC)],
+        );
+        assert_eq!(instances[0]["age"], 10);
+        assert_eq!(instances[1]["age"], 20);
+        assert_eq!(instances[2]["age"], 30);
+    }
+
+    #[test]
+    fn test_filter_properties() {
+        let inst = json!({
+            "id": "test://1",
+            "baseExpression": "test://1",
+            "name": "Test",
+            "age": 25,
+            "secret": "hidden"
+        });
+        let filtered = filter_properties(
+            inst,
+            &["name".to_string(), "age".to_string()],
+        );
+        assert!(filtered.get("id").is_some());
+        assert!(filtered.get("name").is_some());
+        assert!(filtered.get("age").is_some());
+        assert!(filtered.get("secret").is_none());
+    }
+
+    #[test]
+    fn test_parse_shape_from_json() {
+        let json = r#"{
+            "className": "Recipe",
+            "properties": {
+                "name": {
+                    "predicate": "recipe://name",
+                    "required": true,
+                    "flag": false
+                },
+                "rating": {
+                    "predicate": "recipe://rating",
+                    "required": false
+                }
+            },
+            "relations": {
+                "ingredients": {
+                    "predicate": "recipe://ingredient"
+                }
+            }
+        }"#;
+
+        let shape = parse_shape_from_json(json, "Recipe").unwrap();
+        assert_eq!(shape.target_class, "Recipe");
+        assert_eq!(shape.properties.len(), 3);
+        assert!(shape.properties.iter().any(|p| p.name == "name" && p.is_required));
+        assert!(shape.properties.iter().any(|p| p.name == "ingredients" && p.is_collection));
+    }
+}
+
+impl Default for WhereOps {
+    fn default() -> Self {
+        WhereOps {
+            not: None,
+            between: None,
+            lt: None,
+            lte: None,
+            gt: None,
+            gte: None,
+            contains: None,
+        }
+    }
+}

--- a/rust-executor/src/perspectives/model_query.rs
+++ b/rust-executor/src/perspectives/model_query.rs
@@ -131,6 +131,19 @@ struct ShapeProperty {
     datatype: Option<String>,
 }
 
+/// Enriched relation metadata for include (eager-loading) resolution.
+/// Populated when the TS client sends target class shapes alongside the query.
+#[derive(Debug, Clone)]
+struct ShapeRelation {
+    name: String,
+    predicate: String,
+    direction: String,         // "forward" or "reverse"
+    kind: String,              // "hasMany", "hasOne", "belongsToOne", "belongsToMany"
+    max_count: Option<usize>,
+    target_class_name: String,
+    target_shape_json: String, // Serialised ModelMetadata JSON for recursive queries
+}
+
 /// A model shape reconstructed from SHACL links in the store.
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -139,6 +152,9 @@ pub(crate) struct ModelShape {
     #[allow(dead_code)]
     shape_uri: String,
     properties: Vec<ShapeProperty>,
+    /// Enriched relation metadata for include resolution (only populated
+    /// when the TS client sends target shapes for included relations).
+    include_relations: Vec<ShapeRelation>,
 }
 
 // ---------------------------------------------------------------------------
@@ -334,6 +350,7 @@ fn load_shape(store: &SparqlStore, class_name: &str) -> Result<ModelShape, Error
         target_class,
         shape_uri,
         properties,
+        include_relations: Vec::new(),
     })
 }
 
@@ -397,6 +414,32 @@ pub fn execute_model_query(
         load_shape(store, class_name)?
     };
 
+    // ── Fast path: COUNT-only ────────────────────────────────────────────
+    // When the caller only needs a count (limit==0 or count==true) and all
+    // where conditions can be pushed to SPARQL, we skip hydration entirely
+    // and run a single SELECT COUNT(DISTINCT ?source) query.
+    let is_count_only =
+        query_input.count == Some(true) || query_input.limit == Some(0);
+    if is_count_only && all_where_pushable(query_input, &shape) {
+        let sparql = build_count_sparql(&shape, query_input);
+        let result_json = store.query(&sparql)?;
+        let results: Vec<Value> = serde_json::from_str(&result_json)?;
+        let count = results
+            .first()
+            .and_then(|r| {
+                r["cnt"]
+                    .as_str()
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .or_else(|| r["cnt"].as_u64().map(|n| n as usize))
+            })
+            .unwrap_or(0);
+        return Ok(ModelQueryResult {
+            instances: vec![],
+            total_count: count,
+        });
+    }
+
+    // ── Full pipeline ────────────────────────────────────────────────────
     // Build SPARQL to find conforming instances and their property values
     let sparql = build_instance_sparql(&shape, query_input);
 
@@ -431,17 +474,33 @@ pub fn execute_model_query(
 
     // Apply pagination
     let offset = query_input.offset.unwrap_or(0);
-    let paginated: Vec<Value> = if let Some(limit) = query_input.limit {
+    let mut paginated: Vec<Value> = if let Some(limit) = query_input.limit {
         instances.into_iter().skip(offset).take(limit).collect()
     } else {
         instances.into_iter().skip(offset).collect()
     };
 
+    // ── Eager-load included relations ────────────────────────────────────
+    if let Some(ref include) = query_input.include {
+        if !paginated.is_empty() && !shape.include_relations.is_empty() {
+            resolve_includes_recursive(store, &mut paginated, include, &shape)?;
+        }
+    }
+
     // Strip unrequested properties if specified
     let final_instances = if let Some(ref requested) = query_input.properties {
+        // When includes are present, keep the included relation fields
+        let mut keep = requested.clone();
+        if let Some(ref inc) = query_input.include {
+            for rel_name in inc.keys() {
+                if !keep.contains(rel_name) {
+                    keep.push(rel_name.clone());
+                }
+            }
+        }
         paginated
             .into_iter()
-            .map(|inst| filter_properties(inst, requested))
+            .map(|inst| filter_properties(inst, &keep))
             .collect()
     } else {
         paginated
@@ -466,6 +525,7 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
         .to_string();
 
     let mut properties = Vec::new();
+    let mut include_relations: Vec<ShapeRelation> = Vec::new();
 
     // Parse properties from the metadata
     if let Some(props) = meta["properties"].as_object() {
@@ -504,7 +564,7 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
 
             properties.push(ShapeProperty {
                 name: name.clone(),
-                predicate,
+                predicate: predicate.clone(),
                 is_collection: true,
                 is_flag: false,
                 is_required: false,
@@ -512,6 +572,36 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
                 resolve_language: None,
                 datatype: None,
             });
+
+            // Parse enriched relation metadata (target shapes for include resolution)
+            if rel_meta.get("targetShape").is_some() {
+                let target_shape = &rel_meta["targetShape"];
+                let target_class_name = rel_meta["targetClassName"]
+                    .as_str()
+                    .or_else(|| target_shape["className"].as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let kind = rel_meta["kind"]
+                    .as_str()
+                    .unwrap_or("hasMany")
+                    .to_string();
+                let direction = rel_meta["direction"]
+                    .as_str()
+                    .unwrap_or("forward")
+                    .to_string();
+                let max_count = rel_meta["maxCount"].as_u64().map(|n| n as usize);
+
+                include_relations.push(ShapeRelation {
+                    name: name.clone(),
+                    predicate,
+                    direction,
+                    kind,
+                    max_count,
+                    target_class_name,
+                    target_shape_json: serde_json::to_string(target_shape)
+                        .unwrap_or_default(),
+                });
+            }
         }
     }
 
@@ -522,6 +612,7 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
         target_class,
         shape_uri,
         properties,
+        include_relations,
     })
 }
 
@@ -531,6 +622,72 @@ fn parse_shape_from_json(json: &str, class_name: &str) -> Result<ModelShape, Err
 /// 1. Conformance: JOIN on required/flag properties to identify valid instances
 /// 2. Data retrieval: Fetch all links for conforming instances with reifier metadata
 fn build_instance_sparql(shape: &ModelShape, query: &ModelQueryInput) -> String {
+    let (conformance, where_extra) = build_query_patterns(shape, query);
+
+    format!(
+        r#"SELECT ?source ?predicate ?target ?author ?timestamp WHERE {{
+{conformance}
+{where_extra}
+    ?source ?predicate ?target .
+    ?_reifier <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( ?source ?predicate ?target )>> .
+    FILTER(isIRI(?source) && isIRI(?predicate))
+    ?_reifier <ad4m://ontology/author> ?author .
+    ?_reifier <ad4m://ontology/timestamp> ?timestamp .
+}}"#
+    )
+}
+
+/// Build a COUNT SPARQL query that returns the number of conforming instances.
+/// Used as a fast path for count-only queries when all where conditions are SPARQL-pushable.
+fn build_count_sparql(shape: &ModelShape, query: &ModelQueryInput) -> String {
+    let (conformance, where_extra) = build_query_patterns(shape, query);
+
+    format!(
+        r#"SELECT (COUNT(DISTINCT ?source) AS ?cnt) WHERE {{
+{conformance}
+{where_extra}
+    ?source ?_anyPred ?_anyTarget .
+    FILTER(isIRI(?source))
+}}"#
+    )
+}
+
+/// Check whether a query's where clause contains only conditions that can be
+/// pushed to SPARQL (string equality, boolean equality, id/base filters).
+/// If true, a COUNT query can run entirely in SPARQL without hydration.
+fn all_where_pushable(query: &ModelQueryInput, shape: &ModelShape) -> bool {
+    let Some(ref wc) = query.where_clause else {
+        return true;
+    };
+    for (prop_name, condition) in wc {
+        if prop_name == "base" || prop_name == "id" {
+            if matches!(condition, WhereCondition::String(_)) {
+                continue;
+            }
+            return false;
+        }
+        if prop_name == "author"
+            || prop_name == "timestamp"
+            || prop_name == "createdAt"
+            || prop_name == "updatedAt"
+        {
+            return false;
+        }
+        if shape.properties.iter().any(|p| p.name == *prop_name) {
+            match condition {
+                WhereCondition::String(_) | WhereCondition::Bool(_) => continue,
+                _ => return false,
+            }
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+/// Build conformance + where patterns shared by both the instance query and
+/// the COUNT query.  Returns (conformance_patterns, where_patterns) as strings.
+fn build_query_patterns(shape: &ModelShape, query: &ModelQueryInput) -> (String, String) {
     let mut conformance_patterns = Vec::new();
 
     // Parent filter
@@ -667,17 +824,7 @@ fn build_instance_sparql(shape: &ModelShape, query: &ModelQueryInput) -> String 
     let conformance = conformance_patterns.join("\n");
     let where_extra = where_patterns.join("\n");
 
-    format!(
-        r#"SELECT ?source ?predicate ?target ?author ?timestamp WHERE {{
-{conformance}
-{where_extra}
-    ?source ?predicate ?target .
-    ?_reifier <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( ?source ?predicate ?target )>> .
-    FILTER(isIRI(?source) && isIRI(?predicate))
-    ?_reifier <ad4m://ontology/author> ?author .
-    ?_reifier <ad4m://ontology/timestamp> ?timestamp .
-}}"#
-    )
+    (conformance, where_extra)
 }
 
 /// Convert a JS value to its literal: IRI form, matching how the Rust executor
@@ -1248,6 +1395,236 @@ pub(crate) fn resolve_includes(
         let _ = sub_query; // Will be used for nested querying in future
     }
 
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Recursive include resolution (replaces TS-side hydrateRelations)
+// ---------------------------------------------------------------------------
+
+/// Resolve all included relations for a set of instances, recursively handling
+/// nested includes.  Uses enriched relation metadata (target shapes) from the
+/// TS client to call `execute_model_query` in-process, eliminating per-relation
+/// GraphQL round-trips.
+fn resolve_includes_recursive(
+    store: &SparqlStore,
+    instances: &mut [Value],
+    include: &HashMap<String, IncludeValue>,
+    shape: &ModelShape,
+) -> Result<(), Error> {
+    for (rel_name, include_val) in include {
+        match include_val {
+            IncludeValue::Bool(false) => continue,
+            _ => {}
+        }
+
+        // Find the enriched relation metadata
+        let rel = match shape.include_relations.iter().find(|r| r.name == *rel_name) {
+            Some(r) => r,
+            None => continue, // No target shape — can't resolve in Rust
+        };
+
+        let sub_query = match include_val {
+            IncludeValue::Bool(true) => ModelQueryInput::default(),
+            IncludeValue::SubQuery(sq) => *sq.clone(),
+            _ => continue,
+        };
+
+        if rel.direction == "reverse" {
+            resolve_reverse_include(store, instances, rel, &sub_query)?;
+        } else {
+            resolve_forward_include(store, instances, rel, &sub_query)?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a forward relation (hasMany / hasOne) for all instances.
+///
+/// The parent instances already have the target IDs as string arrays (from
+/// hydration).  We batch-query the target class for all those IDs at once,
+/// then replace the string IDs with fully hydrated JSON objects.
+fn resolve_forward_include(
+    store: &SparqlStore,
+    instances: &mut [Value],
+    rel: &ShapeRelation,
+    sub_query: &ModelQueryInput,
+) -> Result<(), Error> {
+    // Collect all target IDs across all instances
+    let mut all_ids: Vec<String> = Vec::new();
+    for inst in instances.iter() {
+        if let Some(arr) = inst[&rel.name].as_array() {
+            for item in arr {
+                if let Some(id) = item.as_str() {
+                    if !all_ids.contains(&id.to_string()) {
+                        all_ids.push(id.to_string());
+                    }
+                }
+            }
+        } else if let Some(id) = inst[&rel.name].as_str() {
+            if !all_ids.contains(&id.to_string()) {
+                all_ids.push(id.to_string());
+            }
+        }
+    }
+    if all_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Build a query: where.id = [...allIds] merged with any sub-query filters
+    let mut query = sub_query.clone();
+    let mut wc = query.where_clause.take().unwrap_or_default();
+    wc.insert("id".to_string(), WhereCondition::StringArray(all_ids));
+    query.where_clause = Some(wc);
+
+    let result = execute_model_query(
+        store,
+        &rel.target_class_name,
+        &query,
+        Some(&rel.target_shape_json),
+    )?;
+
+    // Build id → hydrated instance map
+    let mut hydrated: HashMap<String, Value> = HashMap::new();
+    for inst in result.instances {
+        if let Some(id) = inst["id"].as_str() {
+            hydrated.insert(id.to_string(), inst);
+        }
+    }
+
+    // Replace string IDs with hydrated objects on each parent instance
+    for inst in instances.iter_mut() {
+        let raw = inst[&rel.name].clone();
+        let resolved = if let Some(arr) = raw.as_array() {
+            let items: Vec<Value> = arr
+                .iter()
+                .filter_map(|item| {
+                    item.as_str().and_then(|id| hydrated.get(id).cloned())
+                })
+                .collect();
+            // hasOne (maxCount==1): unwrap to single value
+            if rel.max_count == Some(1) {
+                items.last().cloned().unwrap_or(Value::Null)
+            } else {
+                Value::Array(items)
+            }
+        } else if let Some(id) = raw.as_str() {
+            hydrated.get(id).cloned().unwrap_or(Value::Null)
+        } else {
+            continue;
+        };
+        inst.as_object_mut()
+            .map(|obj| obj.insert(rel.name.clone(), resolved));
+    }
+    Ok(())
+}
+
+/// Resolve a reverse relation (belongsToOne / belongsToMany) for all instances.
+///
+/// Reverse relations are links pointing TO our instances (target = our ID).
+/// We batch-query for all such links, collect source IDs, then hydrate them.
+fn resolve_reverse_include(
+    store: &SparqlStore,
+    instances: &mut [Value],
+    rel: &ShapeRelation,
+    sub_query: &ModelQueryInput,
+) -> Result<(), Error> {
+    let all_ids: Vec<String> = instances
+        .iter()
+        .filter_map(|inst| inst["id"].as_str().map(|s| s.to_string()))
+        .collect();
+    if all_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Batch SPARQL: find all (source, target) pairs for this predicate
+    let id_list = all_ids
+        .iter()
+        .map(|id| format!("<{}>", id))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sparql = format!(
+        "SELECT ?source ?target WHERE {{ ?source <{}> ?target . FILTER(?target IN ({})) }}",
+        rel.predicate, id_list
+    );
+    let result_json = store.query(&sparql)?;
+    let rows: Vec<Value> = serde_json::from_str(&result_json)?;
+
+    // Group source IDs by target (our instance ID)
+    let mut sources_by_target: HashMap<String, Vec<String>> = HashMap::new();
+    for row in &rows {
+        let source = row["source"].as_str().unwrap_or("");
+        let target = row["target"].as_str().unwrap_or("");
+        if !source.is_empty() && !target.is_empty() {
+            sources_by_target
+                .entry(target.to_string())
+                .or_default()
+                .push(source.to_string());
+        }
+    }
+
+    // Collect all unique source IDs for batch hydration
+    let all_source_ids: Vec<String> = {
+        let mut set = std::collections::HashSet::new();
+        for ids in sources_by_target.values() {
+            for id in ids {
+                set.insert(id.clone());
+            }
+        }
+        set.into_iter().collect()
+    };
+
+    // Hydrate source instances
+    let hydrated: HashMap<String, Value> = if all_source_ids.is_empty() {
+        HashMap::new()
+    } else {
+        let mut query = sub_query.clone();
+        let mut wc = query.where_clause.take().unwrap_or_default();
+        wc.insert(
+            "id".to_string(),
+            WhereCondition::StringArray(all_source_ids),
+        );
+        query.where_clause = Some(wc);
+
+        let result = execute_model_query(
+            store,
+            &rel.target_class_name,
+            &query,
+            Some(&rel.target_shape_json),
+        )?;
+
+        let mut map = HashMap::new();
+        for inst in result.instances {
+            if let Some(id) = inst["id"].as_str() {
+                map.insert(id.to_string(), inst);
+            }
+        }
+        map
+    };
+
+    // Assign hydrated instances to each parent
+    for inst in instances.iter_mut() {
+        let inst_id = inst["id"].as_str().unwrap_or("").to_string();
+        let source_ids = sources_by_target
+            .get(&inst_id)
+            .cloned()
+            .unwrap_or_default();
+
+        let resolved = if rel.kind == "belongsToOne" || rel.max_count == Some(1) {
+            source_ids
+                .last()
+                .and_then(|id| hydrated.get(id).cloned())
+                .unwrap_or(Value::Null)
+        } else {
+            let items: Vec<Value> = source_ids
+                .iter()
+                .filter_map(|id| hydrated.get(id).cloned())
+                .collect();
+            Value::Array(items)
+        };
+        inst.as_object_mut()
+            .map(|obj| obj.insert(rel.name.clone(), resolved));
+    }
     Ok(())
 }
 

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2549,9 +2549,8 @@ impl PerspectiveInstance {
         query_json: &str,
         shape_json: Option<&str>,
     ) -> Result<String, deno_core::anyhow::Error> {
-        let query_input: super::model_query::ModelQueryInput =
-            serde_json::from_str(query_json)
-                .map_err(|e| deno_core::anyhow::anyhow!("Failed to parse model query: {}", e))?;
+        let query_input: super::model_query::ModelQueryInput = serde_json::from_str(query_json)
+            .map_err(|e| deno_core::anyhow::anyhow!("Failed to parse model query: {}", e))?;
 
         let result = super::model_query::execute_model_query(
             &self.sparql_store,
@@ -2560,8 +2559,9 @@ impl PerspectiveInstance {
             shape_json,
         )?;
 
-        serde_json::to_string(&result)
-            .map_err(|e| deno_core::anyhow::anyhow!("Failed to serialize model query result: {}", e))
+        serde_json::to_string(&result).map_err(|e| {
+            deno_core::anyhow::anyhow!("Failed to serialize model query result: {}", e)
+        })
     }
 
     pub(crate) async fn persist_link_diff(

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2541,6 +2541,29 @@ impl PerspectiveInstance {
         self.sparql_store.query(&query)
     }
 
+    /// Execute a model query — the executor-side replacement for
+    /// SPARQL-build → hydrate → JS-filter → JS-sort → JS-paginate.
+    pub fn model_query(
+        &self,
+        class_name: &str,
+        query_json: &str,
+        shape_json: Option<&str>,
+    ) -> Result<String, deno_core::anyhow::Error> {
+        let query_input: super::model_query::ModelQueryInput =
+            serde_json::from_str(query_json)
+                .map_err(|e| deno_core::anyhow::anyhow!("Failed to parse model query: {}", e))?;
+
+        let result = super::model_query::execute_model_query(
+            &self.sparql_store,
+            class_name,
+            &query_input,
+            shape_json,
+        )?;
+
+        serde_json::to_string(&result)
+            .map_err(|e| deno_core::anyhow::anyhow!("Failed to serialize model query result: {}", e))
+    }
+
     pub(crate) async fn persist_link_diff(
         &self,
         diff: &DecoratedPerspectiveDiff,


### PR DESCRIPTION
## Summary

Moves ORM model query execution from TypeScript into Rust via a new `perspectiveModelQuery` GraphQL endpoint. The previous pipeline — TS-side SPARQL building → GraphQL round-trip → JS-side hydration → JS-side filtering/sorting — is replaced by a single Rust endpoint that handles the full query lifecycle: SPARQL generation, typed literal parsing, property hydration, where filtering, sorting, pagination, COUNT aggregation, and include (eager loading) resolution.

## Changes

### New: `model_query.rs` (1,876 lines)

Rust model query engine:
- **SPARQL generation** from model shape + query parameters (shared pattern builder for both instance and COUNT queries)
- **Typed literal parsing** via `parse_literal_value()` — parses `literal:` URIs into proper JSON types (strings, numbers, booleans, JSON objects), eliminating the root cause of JS-only filtering (the old `ad4m://fn/parse_literal` returned untyped `xsd:string` for everything)
- **Where filtering** with operators: `equals`, `notEquals`, `gt`, `gte`, `lt`, `lte`, `like`, `in`, `notIn`, `between`
- **Sorting** by any property with ASC/DESC
- **Pagination** via limit/offset
- **SPARQL COUNT fast path** — when all where conditions are SPARQL-pushable (equality, boolean), runs `SELECT COUNT(DISTINCT ?source)` directly instead of hydrating all instances and counting in memory
- **Include (eager loading) resolution** — forward (hasMany/hasOne) and reverse (belongsToOne/belongsToMany) relations resolved recursively in-process, eliminating per-relation GraphQL round-trips
- 15 Rust unit tests

### Modified: TypeScript SDK
- `Ad4mModel.ts`: New `executeModelQuery()` static method bridges TS → Rust; `enrichShapeForIncludes()` recursively walks the include tree and attaches target class shapes; `jsonToModelInstance()` recursively constructs proper class instances from fully-hydrated JSON
- `ModelQueryBuilder.ts`: Routes `executeSparqlQuery()`, `count()`, `paginate()` through `executeModelQuery()`
- `PerspectiveClient.ts` / `PerspectiveProxy.ts`: New `modelQuery()` method
- `Ad4mModel.test.ts`: Updated 14 tests for new mock shape

### Modified: Rust executor
- `query_resolvers.rs`: New `perspectiveModelQuery` resolver
- `perspective_instance.rs`: New `model_query()` method
- `mod.rs`: Exports `model_query` module

## Benchmark Results

All benchmarks run against 115,171 links (real Flux channel data), 10 iterations each. "Before" = `feat/sparql-1.2` (TS-side SPARQL + JS filtering). "After" = this PR.

### First-call performance (cold — what users actually experience)

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| **Full page load** (3 parallel ORM queries) | 3,304ms | 1,555ms | **-53%** |
| Message.findAll(limit:10) | 2,128ms | 373ms | **-82%** |
| Message.findAll(limit:50, offset:100) | 2,151ms | 375ms | **-83%** |
| Channel.findAll() | 638ms | 526ms | **-18%** |
| Conversation.findAll(parent) | 11.7ms | 6.6ms | **-44%** |

### COUNT performance

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| Channel.count() | 484ms* | 5.7ms | **-99%** |

\* Before this PR, `count()` executed a full model query (hydrate all instances, count in JS). Now uses `SELECT COUNT(DISTINCT ?source)` directly in SPARQL.

### Consistency (standard deviation across 10 runs)

| Benchmark | Before σ | After σ | Improvement |
|-----------|----------|---------|-------------|
| Message.findAll(limit:10) | 638ms | 1.5ms | **422× more consistent** |
| Message.findAll(limit:50) | 645ms | 1.7ms | **384× more consistent** |
| Channel.findAll() | 249ms | 5.4ms | **46× more consistent** |
| Full page load | 702ms | 27ms | **26× more consistent** |
| Conversation.get(include) | 197ms | 10ms | **20× more consistent** |
| Message.findAll(parent) | 129ms | 7.0ms | **18× more consistent** |

The baseline had extreme variance because TS-side result caching made repeated identical calls nearly free (< 1ms median), while first calls were 10–100× slower. The Rust endpoint provides consistent performance without caching artifacts.

### Regressions

| Benchmark | Before (1st call) | After (1st call) | Notes |
|-----------|-------------------|-------------------|-------|
| Conversation.get(include: subgroups) | 656ms | 980ms | Recursive include resolution executes sub-queries sequentially; each sub-query dominates |
| Message.findAll(parent) | 356ms | 408ms | +15%, within noise for warm Oxigraph |

The `Conversation.get(include)` regression is an area for future optimization — the Rust include resolver currently issues sequential sub-queries that could be parallelized.

## Test Results
- ✅ 15 Rust unit tests (`cargo test --lib`)
- ✅ 424 TypeScript unit tests (14 suites)
- ✅ 25/25 benchmark tests pass
