### PR TITLE
Feature: IncludeProjection — grouped SPARQL projections via `$`-prefixed include keys

### DIFF
--- a/core/src/model/Ad4mModel.test.ts
+++ b/core/src/model/Ad4mModel.test.ts
@@ -1,5 +1,6 @@
 import { Ad4mModel } from "./Ad4mModel";
-import { Model, Property, Optional, ReadOnly, HasMany, Flag } from "./decorators";
+import { isIncludeProjection } from "./types";
+import { Model, Property, Optional, ReadOnly, HasMany, HasOne, Flag } from "./decorators";
 
 describe("Ad4mModel.getModelMetadata()", () => {
   it("should extract basic model metadata with className", () => {
@@ -2082,5 +2083,190 @@ describe("deepQuery opt-in — getter evaluation", () => {
       (builder as any).deepQuery();
       expect((builder as any).queryParams.deepQuery).toBe(true);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IncludeProjection — key splitting and query routing
+// ---------------------------------------------------------------------------
+
+describe("IncludeProjection type guard and key splitting", () => {
+  // Shared test models
+  @Model({ name: "Signal" })
+  class Signal extends Ad4mModel {
+    @Property({ through: "signal://type" })
+    signalTypeId: string = "";
+
+    @Property({ through: "signal://author" })
+    author: string = "";
+  }
+
+  @Model({ name: "Post" })
+  class Post extends Ad4mModel {
+    @Property({ through: "post://title" })
+    title: string = "";
+
+    @HasMany({ through: "post://signal", target: () => Signal })
+    signals: Signal[] = [];
+
+    @HasMany({ through: "post://comment" })
+    comments: string[] = [];
+  }
+
+  const mockPerspective = {
+    querySparql: jest.fn(),
+    modelQuery: jest.fn(),
+    infer: jest.fn(),
+    uuid: "test-perspective-uuid",
+    stringOrTemplateObjectToSubjectClassName: jest.fn().mockResolvedValue("Post"),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [{ id: "post://1", title: "Hello", $signalCount: 3 }],
+      totalCount: 1,
+    });
+  });
+
+  // --- isIncludeProjection type guard ---
+
+  it("isIncludeProjection returns true for objects with a 'from' field", () => {
+    expect(isIncludeProjection({ from: "signals", count: true })).toBe(true);
+    expect(isIncludeProjection({ from: "comments", limit: 1 })).toBe(true);
+  });
+
+  it("isIncludeProjection returns false for non-projection values", () => {
+    expect(isIncludeProjection(true)).toBe(false);
+    expect(isIncludeProjection(false)).toBe(false);
+    expect(isIncludeProjection(null)).toBe(false);
+    expect(isIncludeProjection(undefined)).toBe(false);
+    expect(isIncludeProjection(42)).toBe(false);
+    // RelationSubQuery (has no 'from' key)
+    expect(isIncludeProjection({ limit: 5, order: { timestamp: "DESC" } })).toBe(false);
+  });
+
+  // --- $-key splitting ---
+
+  it("routes $-prefixed keys to queryInput.projections, not queryInput.include", async () => {
+    await Post.findAll(mockPerspective, {
+      include: {
+        $signalCount: { from: "signals", count: true },
+        comments: true,
+      },
+    });
+
+    const [, queryJson] = mockPerspective.modelQuery.mock.calls[0];
+    const qi = JSON.parse(queryJson);
+
+    // Normal relation goes to include
+    expect(qi.include?.comments).toBe(true);
+    expect(qi.include?.$signalCount).toBeUndefined();
+
+    // Projection goes to projections
+    expect(qi.projections?.$signalCount).toMatchObject({ from: "signals", count: true });
+    expect(qi.projections?.comments).toBeUndefined();
+  });
+
+  it("routes $-prefixed IncludeProjection values to projections ($ prefix required)", async () => {
+    await Post.findAll(mockPerspective, {
+      include: {
+        $mySignals: { from: "signals", limit: 1 },
+        comments: true,
+      },
+    });
+
+    const [, queryJson] = mockPerspective.modelQuery.mock.calls[0];
+    const qi = JSON.parse(queryJson);
+
+    expect(qi.projections?.$mySignals).toMatchObject({ from: "signals", limit: 1 });
+    expect(qi.include?.comments).toBe(true);
+  });
+
+  it("does NOT route non-$ keys to projections even if value has 'from' shape", async () => {
+    // $ prefix is required — a key without it goes to include, not projections
+    await Post.findAll(mockPerspective, {
+      include: {
+        mySignals: { from: "signals", limit: 1 } as any,
+        comments: true,
+      },
+    });
+
+    const [, queryJson] = mockPerspective.modelQuery.mock.calls[0];
+    const qi = JSON.parse(queryJson);
+
+    // Without $ prefix it stays in include (behaviour is undefined/broken but not silently rerouted)
+    expect(qi.projections?.mySignals).toBeUndefined();
+    expect(qi.include?.mySignals).toBeDefined();
+  });
+
+  it("omits queryInput.include when all keys are projections", async () => {
+    await Post.findAll(mockPerspective, {
+      include: {
+        $count: { from: "signals", count: true },
+      },
+    });
+
+    const [, queryJson] = mockPerspective.modelQuery.mock.calls[0];
+    const qi = JSON.parse(queryJson);
+
+    expect(qi.include).toBeUndefined();
+    expect(qi.projections?.$count).toMatchObject({ from: "signals", count: true });
+  });
+
+  it("omits queryInput.projections when all keys are normal includes", async () => {
+    await Post.findAll(mockPerspective, {
+      include: { comments: true },
+    });
+
+    const [, queryJson] = mockPerspective.modelQuery.mock.calls[0];
+    const qi = JSON.parse(queryJson);
+
+    expect(qi.projections).toBeUndefined();
+    expect(qi.include?.comments).toBe(true);
+  });
+
+  it("enriches projection with targetShape when relation target is registered", async () => {
+    await Post.findAll(mockPerspective, {
+      include: {
+        $signalCount: { from: "signals", count: true },
+      },
+    });
+
+    const [, queryJson] = mockPerspective.modelQuery.mock.calls[0];
+    const qi = JSON.parse(queryJson);
+
+    // targetShape should have been injected from the Signal model
+    // ($ prefix is required for projection enrichment to apply)
+    expect(qi.projections?.$signalCount?.targetShape?.className).toBe("Signal");
+  });
+
+  it("leaves targetShape absent when relation has no target decorator", async () => {
+    await Post.findAll(mockPerspective, {
+      include: {
+        $commentCount: { from: "comments", count: true },
+      },
+    });
+
+    const [, queryJson] = mockPerspective.modelQuery.mock.calls[0];
+    const qi = JSON.parse(queryJson);
+
+    // 'comments' HasMany has no target() thunk → no targetShape
+    expect(qi.projections?.$commentCount?.targetShape).toBeUndefined();
+  });
+
+  // --- result passthrough ---
+
+  it("returns $-keyed projection values attached by Rust on instances", async () => {
+    mockPerspective.modelQuery.mockResolvedValue({
+      instances: [{ id: "post://1", title: "Hello", $signalCount: 7 }],
+      totalCount: 1,
+    });
+
+    const results = await Post.findAll(mockPerspective, {
+      include: { $signalCount: { from: "signals", count: true } },
+    });
+
+    expect((results[0] as any).$signalCount).toBe(7);
   });
 });

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -20,7 +20,9 @@ import type {
   ParentScope, IncludeMap, Query,
   GetOptions, AllInstancesResult, ResultsWithTotalCount,
   PaginationResult, PropertyMetadata, RelationMetadata, ModelMetadata,
+  IncludeProjection,
 } from "./types";
+
 
 // ---------------------------------------------------------------------------
 // Helpers for Rust-side include resolution
@@ -958,7 +960,37 @@ export class Ad4mModel {
       queryInput.parent = { id: query.parent.id, predicate: parentPredicate };
     }
     if (query.properties) queryInput.properties = query.properties;
-    if (query.include) queryInput.include = query.include;
+    if (query.include) {
+      // Split include keys: $-prefixed / IncludeProjection values → queryInput.projections
+      // All other keys (boolean | RelationSubQuery) → queryInput.include
+      const normalIncludes: IncludeMap = {};
+      const projections: Record<string, IncludeProjection> = {};
+      for (const [key, val] of Object.entries(query.include)) {
+        if (key.startsWith('$')) {
+          projections[key] = val as IncludeProjection;
+        } else {
+          normalIncludes[key] = val;
+        }
+      }
+      if (Object.keys(normalIncludes).length > 0) queryInput.include = normalIncludes;
+      if (Object.keys(projections).length > 0) {
+        // Enrich projections with target shapes so Rust can apply where clause filtering
+        const allRelMeta = getRelationsMetadata(this as any);
+        for (const [, proj] of Object.entries(projections)) {
+          const relMeta = allRelMeta[proj.from];
+          if (!proj.targetShape && relMeta?.target) {
+            try {
+              const TargetClass = relMeta.target();
+              const targetMeta = (TargetClass as any).getModelMetadata?.();
+              if (targetMeta) {
+                proj.targetShape = targetMeta;
+              }
+            } catch (_) { /* target class may not be available */ }
+          }
+        }
+        queryInput.projections = projections;
+      }
+    }
     if (query.where) queryInput.where = query.where;
     if (query.order) {
       // Convert { propName: 'ASC' | 'DESC' } to [[propName, 'ASC'|'DESC'], ...]
@@ -971,9 +1003,9 @@ export class Ad4mModel {
     // Enrich relation metadata with target class shapes for Rust-side
     // include resolution. This eliminates per-relation GraphQL round-trips
     // by letting the Rust endpoint resolve includes in-process.
-    if (query.include) {
+    if (queryInput.include) {
       const allRelMeta = getRelationsMetadata(this as any);
-      enrichShapeForIncludes(metadata, query.include, allRelMeta);
+      enrichShapeForIncludes(metadata, queryInput.include, allRelMeta);
     }
 
     // ── Pre-compute conformance getters for Rust-side evaluation ──────
@@ -1091,7 +1123,7 @@ export class Ad4mModel {
     // TS-side evaluation as a fallback. Running evaluateCustomGettersForInstance
     // with skipPropertyGetters ensures conformance + JS post-filtering for
     // where clauses that couldn't be compiled to SPARQL.
-    const includedRelNames = query.include ? new Set(Object.keys(query.include)) : new Set<string>();
+    const includedRelNames = queryInput.include ? new Set(Object.keys(queryInput.include)) : new Set<string>();
     for (const inst of instances) {
       // Save included relation values that came from Rust hydration
       const savedIncluded: Record<string, any> = {};
@@ -1123,7 +1155,7 @@ export class Ad4mModel {
     }
 
     // Take snapshots for dirty tracking
-    const snapshotRelations = query.include;
+    const snapshotRelations = queryInput.include;
     for (const inst of instances) {
       (inst as Ad4mModel).takeSnapshot(snapshotRelations);
     }

--- a/core/src/model/types.ts
+++ b/core/src/model/types.ts
@@ -61,7 +61,51 @@ export type ParentScope =
  * ```
  */
 export interface IncludeMap {
-  [relation: string]: boolean | RelationSubQuery;
+  [relation: string]: boolean | RelationSubQuery | IncludeProjection;
+}
+
+/**
+ * A lightweight projection that computes a scalar or list value from a relation
+ * without fully hydrating the linked instances.
+ *
+ * Keys in `IncludeMap` that begin with `$` are treated as projections.
+ * Results are attached directly to each queried instance under the same key.
+ *
+ * @example
+ * ```typescript
+ * // Attach a like-count to each post
+ * const posts = await Post.findAll(perspective, {
+ *   include: {
+ *     $likeCount: { from: 'likes', count: true },
+ *     $myLike:    { from: 'likes', limit: 1 },
+ *   }
+ * });
+ * posts[0].$likeCount  // number
+ * posts[0].$myLike     // string ID or null
+ * ```
+ */
+export interface IncludeProjection {
+  /** The relation name on the parent model to project over. */
+  from: string;
+  /** When true, attaches an integer count instead of a list. */
+  count?: true;
+  /**
+   * Serialised target class shape.  Set automatically by `executeModelQuery`
+   * when a `where` clause is present and the target class is resolvable.
+   * @internal
+   */
+  targetShape?: ModelMetadata;
+  /** Post-hydration where clause applied to the target instances. */
+  where?: Where;
+  /** Limit results (when 1, the attached value is unwrapped to a scalar). */
+  limit?: number;
+  /** Order results before applying limit. */
+  order?: Order;
+}
+
+/** Type guard for IncludeProjection objects. */
+export function isIncludeProjection(val: unknown): val is IncludeProjection {
+  return typeof val === 'object' && val !== null && 'from' in val;
 }
 
 export type Query = {

--- a/rust-executor/src/perspectives/model_query.rs
+++ b/rust-executor/src/perspectives/model_query.rs
@@ -178,6 +178,28 @@ pub enum IncludeValue {
     SubQuery(Box<ModelQueryInput>),
 }
 
+/// Input for a single projection key (mirrors TS IncludeProjection).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionInput {
+    /// The relation name on the parent model to project over.
+    pub from: String,
+    /// When true, attach a count (integer) instead of a list.
+    #[serde(default)]
+    pub count: bool,
+    /// Optional target class shape for resolving where-clause predicates.
+    #[serde(default)]
+    pub target_shape: Option<Value>,
+    /// Optional where filter applied against target instance properties.
+    #[serde(default, rename = "where")]
+    pub where_clause: Option<HashMap<String, WhereCondition>>,
+    /// Limit the number of linked results (when 1, value is unwrapped to scalar).
+    pub limit: Option<usize>,
+    /// Order results before limiting.
+    #[serde(default, deserialize_with = "deserialize_order_flex")]
+    pub order: Option<Vec<(String, OrderDirection)>>,
+}
+
 /// The structured query input (mirrors TS Query type).
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -188,6 +210,10 @@ pub struct ModelQueryInput {
     pub properties: Option<Vec<String>>,
     #[serde(default)]
     pub include: Option<HashMap<String, IncludeValue>>,
+    /// Projection keys (begin with `$`): lightweight aggregations/lists that
+    /// are computed Rust-side with a single grouped SPARQL per key.
+    #[serde(default)]
+    pub projections: Option<HashMap<String, ProjectionInput>>,
     #[serde(default, rename = "where")]
     pub where_clause: Option<HashMap<String, WhereCondition>>,
     #[serde(default, deserialize_with = "deserialize_order_flex")]
@@ -540,6 +566,359 @@ fn get_initial_value(
 // Core query execution
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Projection resolution ($-prefixed keys)
+// ---------------------------------------------------------------------------
+
+/// Resolve projection keys for a set of already-paginated instances.
+///
+/// For each key in `projections`, issues a single grouped SPARQL query
+/// (O(1) per key) and attaches results to the matching instances.
+///
+/// - `count: true` → attaches an integer (0 when no links exist).
+/// - `limit: Some(1)` → attaches the first linked ID as a string, or `null`.
+/// - otherwise → attaches an array of linked IDs.
+fn resolve_projections(
+    store: &SparqlStore,
+    instances: &mut Vec<Value>,
+    projections: &HashMap<String, ProjectionInput>,
+    shape: &ModelShape,
+) -> Result<(), Error> {
+    if instances.is_empty() || projections.is_empty() {
+        return Ok(());
+    }
+
+    // Collect parent IDs (validate each as a safe IRI).
+    let parent_ids: Vec<String> = instances
+        .iter()
+        .filter_map(|inst| inst["id"].as_str())
+        .filter_map(|id| validate_iri(id).ok().map(|s| s.to_string()))
+        .collect();
+
+    if parent_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Build VALUES clause: `<id1> <id2> …`
+    let values_clause = parent_ids
+        .iter()
+        .map(|id| format!("<{}>", id))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    for (key, proj) in projections {
+        // ------------------------------------------------------------------
+        // 1. Resolve predicate from the parent shape's properties/relations.
+        // ------------------------------------------------------------------
+        let predicate = match shape.properties.iter().find(|p| p.name == proj.from) {
+            Some(p) if !p.predicate.is_empty() => p.predicate.clone(),
+            Some(_) => {
+                log::warn!(
+                    "IncludeProjection '{}': relation '{}' has empty predicate — skipping",
+                    key, proj.from
+                );
+                continue;
+            }
+            None => {
+                log::warn!(
+                    "IncludeProjection '{}': relation '{}' not found in shape — skipping",
+                    key, proj.from
+                );
+                continue;
+            }
+        };
+
+        let safe_pred = match validate_iri(&predicate) {
+            Ok(p) => p.to_string(),
+            Err(_) => {
+                log::warn!(
+                    "IncludeProjection '{}': predicate '{}' is not a valid IRI — skipping",
+                    key, predicate
+                );
+                continue;
+            }
+        };
+
+        // ------------------------------------------------------------------
+        // 2. Build optional where-clause patterns for target properties.
+        // ------------------------------------------------------------------
+        let where_patterns = build_projection_where_patterns(proj);
+
+        // ------------------------------------------------------------------
+        // 3. Issue the grouped SPARQL query and attach results.
+        // ------------------------------------------------------------------
+        if proj.count {
+            // COUNT query — returns one row per parent with the count.
+            let sparql = format!(
+                concat!(
+                    "SELECT ?parent (COUNT(DISTINCT ?t) AS ?n) WHERE {{\n",
+                    "    VALUES ?parent {{ {values_clause} }}\n",
+                    "    ?parent <{safe_pred}> ?t .\n",
+                    "{where_patterns}",
+                    "}} GROUP BY ?parent"
+                ),
+                values_clause = values_clause,
+                safe_pred = safe_pred,
+                where_patterns = where_patterns,
+            );
+
+            let result_json = store.query(&sparql)?;
+            let rows: Vec<Value> = serde_json::from_str(&result_json)?;
+
+            // parent_id → count
+            let mut count_map: HashMap<String, u64> = HashMap::new();
+            for row in &rows {
+                let parent = row["parent"].as_str().unwrap_or("");
+                let n: u64 = row["n"]
+                    .as_str()
+                    .and_then(|s| s.parse().ok())
+                    .or_else(|| row["n"].as_u64())
+                    .unwrap_or(0);
+                count_map.insert(parent.to_string(), n);
+            }
+
+            for inst in instances.iter_mut() {
+                if let Some(obj) = inst.as_object_mut() {
+                    let id = obj
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let cnt = count_map.get(&id).copied().unwrap_or(0);
+                    obj.insert(key.clone(), Value::Number(cnt.into()));
+                }
+            }
+        } else {
+            // LIST / SCALAR query.
+            // Note: LIMIT is NOT added to the SPARQL — a global LIMIT on a
+            // VALUES-clause query limits the *total* row count, not per-parent.
+            // Instead we collect all rows and truncate per-parent in Rust below.
+            let order_clause = build_projection_order_clause(proj);
+
+            let sparql = format!(
+                concat!(
+                    "SELECT ?parent ?t WHERE {{\n",
+                    "    VALUES ?parent {{ {values_clause} }}\n",
+                    "    ?parent <{safe_pred}> ?t .\n",
+                    "{where_patterns}",
+                    "}}{order_clause}"
+                ),
+                values_clause = values_clause,
+                safe_pred = safe_pred,
+                where_patterns = where_patterns,
+                order_clause = order_clause,
+            );
+
+            let result_json = store.query(&sparql)?;
+            let rows: Vec<Value> = serde_json::from_str(&result_json)?;
+
+            // parent_id → Vec<target_id>
+            let mut list_map: HashMap<String, Vec<Value>> = HashMap::new();
+            for row in &rows {
+                if let Some(parent) = row["parent"].as_str() {
+                    let t = row["t"]
+                        .as_str()
+                        .map(|s| Value::String(s.to_string()))
+                        .unwrap_or(Value::Null);
+                    list_map.entry(parent.to_string()).or_default().push(t);
+                }
+            }
+
+            for inst in instances.iter_mut() {
+                if let Some(obj) = inst.as_object_mut() {
+                    let id = obj
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let val = match proj.limit {
+                        Some(1) => list_map
+                            .get(&id)
+                            .and_then(|v| v.first().cloned())
+                            .unwrap_or(Value::Null),
+                        Some(n) => Value::Array(
+                            list_map
+                                .get(&id)
+                                .cloned()
+                                .unwrap_or_default()
+                                .into_iter()
+                                .take(n)
+                                .collect(),
+                        ),
+                        None => Value::Array(list_map.get(&id).cloned().unwrap_or_default()),
+                    };
+                    obj.insert(key.clone(), val);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Build SPARQL triple patterns for a projection's `where` clause.
+///
+/// When a `targetShape` is supplied, property names in the `where` clause are
+/// resolved to their predicate IRIs.  Without a target shape, only `id`/`base`
+/// (direct IRI equality) filters are supported.
+///
+/// Returns a string ready to insert into the SPARQL `WHERE {}` block (each
+/// line already ends with `\n`).
+fn build_projection_where_patterns(proj: &ProjectionInput) -> String {
+    let Some(ref wc) = proj.where_clause else {
+        return String::new();
+    };
+
+    // Try to build a property-name → predicate lookup from the target shape.
+    let pred_lookup: HashMap<String, String> = if let Some(ref ts) = proj.target_shape {
+        let mut map = HashMap::new();
+        if let Some(props) = ts["properties"].as_object() {
+            for (name, pm) in props {
+                if let Some(pred) = pm["predicate"].as_str() {
+                    if !pred.is_empty() {
+                        map.insert(name.clone(), pred.to_string());
+                    }
+                }
+            }
+        }
+        if let Some(rels) = ts["relations"].as_object() {
+            for (name, rm) in rels {
+                if let Some(pred) = rm["predicate"].as_str() {
+                    if !pred.is_empty() {
+                        map.insert(name.clone(), pred.to_string());
+                    }
+                }
+            }
+        }
+        map
+    } else {
+        HashMap::new()
+    };
+
+    let mut patterns = Vec::new();
+    let mut filter_idx = 0usize;
+
+    for (prop_name, condition) in wc {
+        // id / base → direct IRI equality on ?t
+        if prop_name == "id" || prop_name == "base" {
+            match condition {
+                WhereCondition::String(val) => {
+                    let escaped = escape_sparql_string(val);
+                    patterns.push(format!(
+                        "    FILTER(STR(?t) = \"{}\")\n",
+                        escaped
+                    ));
+                }
+                WhereCondition::StringArray(vals) => {
+                    let list = vals
+                        .iter()
+                        .map(|v| format!("\"{}\"", escape_sparql_string(v)))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    patterns.push(format!("    FILTER(STR(?t) IN ({}))\n", list));
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        // author / timestamp — standard metadata fields (not link targets, skip for now)
+        if prop_name == "author" || prop_name == "timestamp" {
+            continue;
+        }
+
+        // Resolve via target shape
+        let pred = match pred_lookup.get(prop_name) {
+            Some(p) => p.clone(),
+            None => continue, // unknown property without a shape — skip
+        };
+
+        if let Err(_) = validate_iri(&pred) {
+            continue;
+        }
+
+        let var = format!("_pw{}", filter_idx);
+        filter_idx += 1;
+        let safe_var = var.replace(|c: char| !c.is_alphanumeric() && c != '_', "_");
+
+        match condition {
+            WhereCondition::String(val) => {
+                let escaped = escape_sparql_string(val);
+                patterns.push(format!("    ?t <{}> ?{} .\n", pred, safe_var));
+                // Values may be stored as literal: URIs — use STR() for comparison.
+                patterns.push(format!(
+                    "    FILTER(STR(?{}) = \"{}\" || STR(?{}) = \"literal:string:{}\")\n",
+                    safe_var, escaped,
+                    safe_var, urlencoding::encode(val),
+                ));
+            }
+            WhereCondition::Bool(b) => {
+                let bval = if *b { "true" } else { "false" };
+                patterns.push(format!("    ?t <{}> ?{} .\n", pred, safe_var));
+                patterns.push(format!(
+                    "    FILTER(STR(?{}) = \"{}\" || STR(?{}) = \"literal:boolean:{}\")\n",
+                    safe_var, bval, safe_var, bval,
+                ));
+            }
+            WhereCondition::Number(n) => {
+                patterns.push(format!("    ?t <{}> ?{} .\n", pred, safe_var));
+                patterns.push(format!(
+                    "    FILTER(STR(?{}) = \"{}\" || STR(?{}) = \"literal:number:{}\")\n",
+                    safe_var, n, safe_var, n,
+                ));
+            }
+            WhereCondition::StringArray(vals) => {
+                let list = vals
+                    .iter()
+                    .flat_map(|v| {
+                        let r = escape_sparql_string(v);
+                        let e = urlencoding::encode(v).to_string();
+                        vec![
+                            format!("\"{}\"", r),
+                            format!("\"literal:string:{}\"", e),
+                        ]
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                patterns.push(format!("    ?t <{}> ?{} .\n", pred, safe_var));
+                patterns.push(format!("    FILTER(STR(?{}) IN ({}))\n", safe_var, list));
+            }
+            _ => {} // complex ops not yet supported for projections
+        }
+    }
+
+    patterns.join("")
+}
+
+/// Build an `ORDER BY` clause string for a list projection.
+///
+/// Only `id`/`base` (which map to `?t`) are supported — ordering by arbitrary
+/// child properties would require an extra JOIN in the projection query.
+/// Returns a string starting with `\n` (e.g. `"\nORDER BY ASC(?t)"`) or empty.
+fn build_projection_order_clause(proj: &ProjectionInput) -> String {
+    let Some(ref order) = proj.order else {
+        return String::new();
+    };
+    let terms: Vec<String> = order
+        .iter()
+        .filter_map(|(k, dir)| {
+            if k == "id" || k == "base" {
+                Some(match dir {
+                    OrderDirection::ASC => "ASC(?t)".to_string(),
+                    OrderDirection::DESC => "DESC(?t)".to_string(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+    if terms.is_empty() {
+        String::new()
+    } else {
+        format!("\nORDER BY {}", terms.join(" "))
+    }
+}
+
 /// Execute a model query against the Oxigraph store.
 ///
 /// This is the main entry point that replaces the TS SPARQL-build → hydrate → filter pipeline.
@@ -675,7 +1054,7 @@ fn execute_model_query_inner(
     }
 
     // Strip unrequested properties if specified
-    let final_instances = if let Some(ref requested) = query_input.properties {
+    let mut final_instances: Vec<Value> = if let Some(ref requested) = query_input.properties {
         // When includes are present, keep the included relation fields
         let mut keep = requested.clone();
         if let Some(ref inc) = query_input.include {
@@ -692,6 +1071,12 @@ fn execute_model_query_inner(
     } else {
         paginated
     };
+
+    // ── Attach projection results ($-prefixed aggregations / lists) ──────
+    // Issued as one grouped VALUES SPARQL per key — O(projections) total.
+    if let Some(ref projections) = query_input.projections {
+        resolve_projections(store, &mut final_instances, projections, &shape)?;
+    }
 
     Ok(ModelQueryResult {
         instances: final_instances,
@@ -3124,5 +3509,102 @@ mod integration_tests {
         assert_eq!(alpha[0].as_str().unwrap(), "literal:string:shared_child");
         assert_eq!(beta[0].as_str().unwrap(), "literal:string:shared_child");
         assert_eq!(special[0].as_str().unwrap(), "literal:string:special_child");
+    }
+
+    // --- IncludeProjection helpers ---
+
+    #[test]
+    fn test_build_projection_where_patterns_empty_when_no_clause() {
+        let proj = ProjectionInput {
+            from: "signals".to_string(),
+            count: true,
+            target_shape: None,
+            where_clause: None,
+            limit: None,
+            order: None,
+        };
+        assert_eq!(build_projection_where_patterns(&proj), "");
+    }
+
+    #[test]
+    fn test_build_projection_where_patterns_id_filter() {
+        let mut wc = HashMap::new();
+        wc.insert(
+            "id".to_string(),
+            WhereCondition::String("signal://abc".to_string()),
+        );
+        let proj = ProjectionInput {
+            from: "signals".to_string(),
+            count: false,
+            target_shape: None,
+            where_clause: Some(wc),
+            limit: None,
+            order: None,
+        };
+        let patterns = build_projection_where_patterns(&proj);
+        assert!(
+            patterns.contains("FILTER(STR(?t) = \"signal://abc\")"),
+            "expected id IRI filter, got: {patterns}"
+        );
+    }
+
+    #[test]
+    fn test_build_projection_where_patterns_with_target_shape() {
+        let target_shape = json!({
+            "className": "Signal",
+            "properties": {
+                "signalTypeId": { "predicate": "signal://type" }
+            },
+            "relations": {}
+        });
+        let mut wc = HashMap::new();
+        wc.insert(
+            "signalTypeId".to_string(),
+            WhereCondition::String("like".to_string()),
+        );
+        let proj = ProjectionInput {
+            from: "signals".to_string(),
+            count: true,
+            target_shape: Some(target_shape),
+            where_clause: Some(wc),
+            limit: None,
+            order: None,
+        };
+        let patterns = build_projection_where_patterns(&proj);
+        assert!(
+            patterns.contains("?t <signal://type>"),
+            "expected triple pattern for signal://type, got: {patterns}"
+        );
+        assert!(
+            patterns.contains("FILTER(STR(?"),
+            "expected FILTER, got: {patterns}"
+        );
+    }
+
+    #[test]
+    fn test_build_projection_order_clause_empty_when_no_order() {
+        let proj = ProjectionInput {
+            from: "signals".to_string(),
+            count: false,
+            target_shape: None,
+            where_clause: None,
+            limit: Some(5),
+            order: None,
+        };
+        assert_eq!(build_projection_order_clause(&proj), "");
+    }
+
+    #[test]
+    fn test_build_projection_order_clause_by_id() {
+        let proj = ProjectionInput {
+            from: "signals".to_string(),
+            count: false,
+            target_shape: None,
+            where_clause: None,
+            limit: None,
+            order: Some(vec![("id".to_string(), OrderDirection::DESC)]),
+        };
+        let clause = build_projection_order_clause(&proj);
+        assert!(clause.contains("ORDER BY DESC(?t)"), "got: {clause}");
     }
 }

--- a/rust-executor/src/perspectives/model_query.rs
+++ b/rust-executor/src/perspectives/model_query.rs
@@ -615,14 +615,16 @@ fn resolve_projections(
             Some(_) => {
                 log::warn!(
                     "IncludeProjection '{}': relation '{}' has empty predicate — skipping",
-                    key, proj.from
+                    key,
+                    proj.from
                 );
                 continue;
             }
             None => {
                 log::warn!(
                     "IncludeProjection '{}': relation '{}' not found in shape — skipping",
-                    key, proj.from
+                    key,
+                    proj.from
                 );
                 continue;
             }
@@ -633,7 +635,8 @@ fn resolve_projections(
             Err(_) => {
                 log::warn!(
                     "IncludeProjection '{}': predicate '{}' is not a valid IRI — skipping",
-                    key, predicate
+                    key,
+                    predicate
                 );
                 continue;
             }
@@ -804,10 +807,7 @@ fn build_projection_where_patterns(proj: &ProjectionInput) -> String {
             match condition {
                 WhereCondition::String(val) => {
                     let escaped = escape_sparql_string(val);
-                    patterns.push(format!(
-                        "    FILTER(STR(?t) = \"{}\")\n",
-                        escaped
-                    ));
+                    patterns.push(format!("    FILTER(STR(?t) = \"{}\")\n", escaped));
                 }
                 WhereCondition::StringArray(vals) => {
                     let list = vals
@@ -848,8 +848,10 @@ fn build_projection_where_patterns(proj: &ProjectionInput) -> String {
                 // Values may be stored as literal: URIs — use STR() for comparison.
                 patterns.push(format!(
                     "    FILTER(STR(?{}) = \"{}\" || STR(?{}) = \"literal:string:{}\")\n",
-                    safe_var, escaped,
-                    safe_var, urlencoding::encode(val),
+                    safe_var,
+                    escaped,
+                    safe_var,
+                    urlencoding::encode(val),
                 ));
             }
             WhereCondition::Bool(b) => {
@@ -873,10 +875,7 @@ fn build_projection_where_patterns(proj: &ProjectionInput) -> String {
                     .flat_map(|v| {
                         let r = escape_sparql_string(v);
                         let e = urlencoding::encode(v).to_string();
-                        vec![
-                            format!("\"{}\"", r),
-                            format!("\"literal:string:{}\"", e),
-                        ]
+                        vec![format!("\"{}\"", r), format!("\"literal:string:{}\"", e)]
                     })
                     .collect::<Vec<_>>()
                     .join(", ");


### PR DESCRIPTION
# IncludeProjection — grouped SPARQL projections via `$`-prefixed include keys

**Branch:** `feat/include-projections-v2`  
**Target:** `feat/sparql-1.2-cleanup`  
**Commit:** `b8956ee53`

---

## Summary

Adds `IncludeProjection` as a new include-map value type, allowing callers to attach lightweight aggregations or sub-lists to query results without triggering the N+1 pattern. Projections are declared with a `$`-prefixed key and resolved entirely in Rust using a single grouped VALUES SPARQL per key — O(P) total queries regardless of result set size.

```typescript
// count how many signals each post has
const posts = await Post.findAll(perspective, {
  include: {
    $signalCount: { from: 'signals', count: true },
    $latestSignal: { from: 'signals', limit: 1, order: { id: 'DESC' } },
    comments: true, // normal include — unaffected
  },
});
// posts[0].$signalCount → 7
// posts[0].$latestSignal → "signal://abc"
// posts[0].comments     → [...] (eager-loaded as before)
```

---

## Motivation

The existing `include` map supports eager-loading full relation objects (`comments: true`) and sub-queries (`comments: { where: {...} }`). Neither approach is cheap when you only need a count or the first item — they hydrate all linked instances. Before this PR, callers worked around this by issuing separate queries or doing post-processing in JS, both of which reintroduce N+1 behaviour.

---

## Design decisions

### `$` prefix as the discriminator
The `$` prefix is the only signal that a key is a projection. There is no fallback value-type dispatch — a key without `$` always goes to `queryInput.include`, even if its value happens to have a `from` field. This is intentional: silent rerouting based on value shape is confusing and hard to debug.

### Why Rust-native, not TS post-processing
TS post-processing would require fetching all linked instances first (N per parent) then counting/slicing in JS — exactly the N+1 pattern this feature exists to avoid. Rust's grouped VALUES SPARQL issues one query per projection key regardless of how many parent instances are on the page.

### `limit` applied per-parent in Rust, not via SPARQL LIMIT
A global `LIMIT N` on a `VALUES ?parent { ... }` query caps the *total* row count across all parents, so most parents would get fewer results than requested. Instead, the SPARQL fetches all rows and Rust truncates per-parent after collecting into a `HashMap<parent_id, Vec<target>>`.

---

## Changes

### `core/src/model/types.ts`
- Added `IncludeProjection` interface (`from`, `count?`, `targetShape?`, `where?`, `limit?`, `order?`)
- Added `isIncludeProjection(val)` type guard (`'from' in val`)
- Updated `IncludeMap` value union to `boolean | RelationSubQuery | IncludeProjection`

### `core/src/model/Ad4mModel.ts`
- `executeModelQuery`: replaced the single-line `queryInput.include = query.include` with a splitting loop — `$`-prefixed keys → `queryInput.projections`, all others → `queryInput.include`
- Projections are enriched with `targetShape` (via `relMeta.target()`) when available, so Rust can resolve `where` clause predicates without a second round-trip
- `includedRelNames`, `snapshotRelations`, and `enrichShapeForIncludes` now reference `queryInput.include` (the filtered normal-includes map) rather than `query.include`, preventing projection keys from leaking into dirty-tracking and getter-save logic

### `rust-executor/src/perspectives/model_query.rs`
- Added `ProjectionInput` struct (mirrors `IncludeProjection` TS type)
- Added `projections: Option<HashMap<String, ProjectionInput>>` field to `ModelQueryInput`
- `resolve_projections()`: grouped VALUES SPARQL per key; count path uses `GROUP BY ?parent`, list path collects all rows then truncates per-parent in Rust
- `build_projection_where_patterns()`: resolves `where` clause to SPARQL patterns using `targetShape` for predicate lookup; handles `id`/`base` IRI equality, `String`/`Bool`/`Number`/`StringArray` conditions
- `build_projection_order_clause()`: emits direction-terms (`ASC(?t)`/`DESC(?t)`) joined under a single `ORDER BY` keyword
- `execute_model_query_inner`: calls `resolve_projections` after pagination and `filter_properties`, so `$` keys are added to the final output objects rather than being stripped

### `core/src/model/Ad4mModel.test.ts`
10 new tests in `"IncludeProjection type guard and key splitting"`:
- `isIncludeProjection` returns true/false correctly
- `$`-prefixed keys route to `projections`, not `include`
- Non-`$` keys do NOT route to projections even with a `from`-shaped value
- `include`/`projections` omitted when empty
- `targetShape` enrichment with and without a declared target class
- Result passthrough of `$`-keyed values from Rust

### `rust-executor/src/perspectives/model_query.rs` (tests)
5 new unit tests:
- `build_projection_where_patterns` — empty clause, `id` filter, target-shape property filter
- `build_projection_order_clause` — empty when no order, `ORDER BY DESC(?t)` for `id: DESC`

---

## Bugs fixed during review

| Bug | Impact | Fix |
|-----|--------|-----|
| Global `LIMIT` in list-projection SPARQL | With N parents and `limit: 3`, only 3 total rows returned — most parents get `null` | Removed LIMIT from SPARQL; Rust truncates per-parent with `.take(n)` |
| `ORDER BY` keyword emitted per term | Multiple order terms produced `ORDER BY ASC(?t) ORDER BY DESC(?t)` — invalid SPARQL | Terms now emit `ASC(?t)`/`DESC(?t)`, wrapped once in `ORDER BY` |

---

## Known limitations

- `where` clause filtering in projections uses `STR(?v) = "literal:string:..."` patterns. Properties stored as signed JSON envelopes (`resolveLanguage: 'literal'`) won't match. This is the same limitation as the main query's push-down filters and is documented there. For the primary use cases (`count: true`, IRI-valued relation targets) this doesn't matter.
- `order` in list projections only supports `id`/`base` (i.e. ordering by the linked IRI itself). Ordering by a child property would require a JOIN in the projection SPARQL — out of scope for this PR.
