### PR TITLE
Feature: includeAll operator + HasMany deprecation warning

### DIFF
--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -950,6 +950,20 @@ export class Ad4mModel {
     const metadata = this.getModelMetadata();
     const className = classNameOverride || metadata.className;
 
+    // Expand includeAll: true to a full IncludeMap covering every forward relation.
+    // Done before queryInput is built so all downstream uses of query.include see the expansion.
+    if (query.includeAll) {
+      const allRelMeta = getRelationsMetadata(this as any);
+      const expanded: IncludeMap = {};
+      for (const [relName, relMeta] of Object.entries(allRelMeta)) {
+        if ((relMeta as any).direction !== 'reverse') {
+          expanded[relName] = true;
+        }
+      }
+      // Explicit include entries take precedence over the expansion
+      query = { ...query, include: { ...expanded, ...query.include } };
+    }
+
     // Build the query input that the Rust endpoint expects.
     // Convert the TS Query type to the executor's ModelQueryInput format.
     const queryInput: any = {};

--- a/core/src/model/decorators.ts
+++ b/core/src/model/decorators.ts
@@ -858,8 +858,17 @@ export function HasMany(
     first: (() => Ad4mModelLike) | RelationOptions,
     second?: Omit<RelationOptions, 'target'>,
 ): PropertyDecorator {
+    const explicitThrough = typeof first === 'function' ? second?.through : (first as RelationOptions).through;
     const opts = resolveRelationArgs(first, second);
     return function <T>(target: T, key: keyof T) {
+        if (!explicitThrough && !opts.getter) {
+            const className = ((target as any).constructor?.name) ?? 'unknown';
+            console.warn(
+                `@HasMany on ${className}.${String(key)} has no 'through' predicate — defaulting to 'ad4m://has_child'. ` +
+                `Add { through: 'ad4m://has_child' } to silence this warning, or use a semantic predicate ` +
+                `like { through: 'myns://has_${String(key)}' } for efficient targeted queries.`
+            );
+        }
         // --- relation registry ---
         const ctor = (target as any).constructor;
         if (!relationRegistry.has(ctor)) relationRegistry.set(ctor, {});

--- a/core/src/model/types.ts
+++ b/core/src/model/types.ts
@@ -69,6 +69,13 @@ export type Query = {
   parent?: ParentScope;
   properties?: string[];
   include?: IncludeMap;
+  /**
+   * When true, eager-loads every declared forward relation on the model.
+   * Equivalent to listing all relation field names in `include: {}` explicitly.
+   * Useful for tree-walking and manifest-style inspections.
+   * Individual relations can still be overridden via `include` (explicit entries take precedence).
+   */
+  includeAll?: boolean;
   where?: Where;
   order?: Order;
   offset?: number;


### PR DESCRIPTION
# Semantic Relation Predicates — Phase 1

**Branch:** `feat/semantic-relation-predicates`
**Base:** `feat/sparql-1.2-cleanup`
**Commit:** `d6fd770d4`
**Repo:** `coasys/ad4m`

---

## What this PR does

Two changes, both non-breaking:

### 1. `includeAll: true` operator on `Query`

Adds `includeAll?: boolean` to the `Query` type. When set, `executeModelQuery` expands it to a full `IncludeMap` covering every declared forward relation on the model before building the query input — identical in effect to listing all relation names in `include: {}` manually.

```typescript
// Hydrates every declared relation in one call
const channel = await Channel.get(id, { includeAll: true });
// channel.messages, channel.conversations, channel.tasks — all populated

// Works on collection queries too (limit scopes the parent instances, not the children)
const channels = await Channel.all({ includeAll: true, limit: 10 });
```

Explicit `include` entries take precedence over the expansion — you can override individual relations while still using `includeAll` for the rest.

**Implementation:** Pure TS pre-processing inside `executeModelQuery`. The expanded `IncludeMap` is passed through the identical path as a manual `include`, including Rust-side `enrichShapeForIncludes` and in-process relation resolution. Zero Rust executor changes.

### 2. `@HasMany` deprecation warning when `through` is omitted

`HasMany` now emits a `console.warn` when neither `through` nor `getter` is provided, naming the affected class and field:

```
@HasMany on Channel.messages has no 'through' predicate — defaulting to 'ad4m://has_child'.
Add { through: 'ad4m://has_child' } to silence this warning, or use a semantic predicate
like { through: 'myns://has_messages' } for efficient targeted queries.
```

Behaviour is otherwise unchanged — `ad4m://has_child` is still the default. This is Phase 1 of a migration toward explicit semantic predicates; a hard error will follow in a future major version bump.

---

## Files changed

| File | Change |
|---|---|
| `core/src/model/types.ts` | Add `includeAll?: boolean` to `Query` with JSDoc |
| `core/src/model/Ad4mModel.ts` | Expand `includeAll` at the top of `executeModelQuery` |
| `core/src/model/decorators.ts` | Emit `console.warn` in `HasMany` when `through` is absent |

---

## Why

See the full rationale in [we/docs/internal/plans/prs/semantic-relation-predicates.md](../semantic-relation-predicates.md). In brief:

- All Flux `@HasMany` fields currently default silently to `ad4m://has_child`. Every `include` query over-fetches (O(total children), not O(relation size)) and `parent` resolution is non-deterministic when two fields target the same class.
- `includeAll` makes tree-walking expressible in the model DSL without raw SPARQL, removing the main remaining motivation for using `has_child` as a universal predicate.
- The deprecation warning makes the implicit default visible in logs so developers can add explicit predicates at their own pace.

---

## Merge order

This PR is independent of `feat/include-projections-v2` and `feat/model-manifest` at the logic level. All three can merge in any order; the 3-way merge on `types.ts` and `Ad4mModel.ts` is mechanical (non-overlapping sections).

---

## Tests

All 377 existing tests pass. No new tests added in this PR — `includeAll` expansion is a trivial pre-processing step; coverage for include hydration already exists in the test suite.
