### PR TITLE
Fix: SHACL `sh:class` Link Emission + `fromSHACL` classResolver

### DIFF
--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -2173,7 +2173,24 @@ export class Ad4mModel {
    * @param name  - Class name to assign (e.g. "Channel")
    * @returns Generated Ad4mModel subclass, ready for querying
    */
-  static fromSHACL(shape: SHACLShape, name: string): typeof Ad4mModel {
+  /**
+   * Synthesise an `Ad4mModel` subclass from a SHACL shape.
+   *
+   * @param shape           - The SHACL shape to synthesise from.
+   * @param name            - The model name (e.g. "Channel").
+   * @param classResolver   - Optional thunk factory.  When provided, any collection
+   *   property that carries a `sh:class` URI will have its `target` wired up lazily:
+   *   `target: () => classResolver(localName)`.  Because `target` is only called at
+   *   query time (inside `enrichShapeForIncludes` / `jsonToModelInstance`), the
+   *   resolver just needs to return the correct class by the time a query runs —
+   *   making it safe to pass a closure over a registry object that is still being
+   *   populated (e.g. the `result` record inside `getModelClasses`).
+   */
+  static fromSHACL(
+    shape: SHACLShape,
+    name: string,
+    classResolver?: (localName: string) => typeof Ad4mModel | undefined,
+  ): typeof Ad4mModel {
     const DynamicModelClass = class extends (this as any) {} as unknown as typeof Ad4mModel;
     (DynamicModelClass as any).className = name;
     (DynamicModelClass.prototype as any).className = name;
@@ -2218,9 +2235,20 @@ export class Ad4mModel {
       const isCollection = prop.maxCount === undefined || prop.maxCount > 1;
 
       if (isCollection) {
+        // Derive a lazy `target` thunk when a sh:class URI is present and a
+        // classResolver was supplied.  The thunk is evaluated at query time so
+        // it is safe even if the target class hasn't been registered yet.
+        let targetThunk: (() => typeof Ad4mModel) | undefined;
+        if (prop.class && classResolver) {
+          const sep = Math.max(prop.class.lastIndexOf('#'), prop.class.lastIndexOf('/'));
+          const localName = sep >= 0 ? prop.class.slice(sep + 1) : prop.class;
+          targetThunk = () => classResolver(localName) as typeof Ad4mModel;
+        }
+
         setRelationRegistryEntry(DynamicModelClass, prop.name, {
           predicate: prop.path,
           kind: 'hasMany',
+          ...(targetThunk !== undefined && { target: targetThunk }),
           ...(prop.local !== undefined && { local: prop.local }),
           ...(prop.getter !== undefined && { getter: prop.getter }),
         });

--- a/rust-executor/src/perspectives/shacl_parser.rs
+++ b/rust-executor/src/perspectives/shacl_parser.rs
@@ -499,6 +499,35 @@ pub fn parse_shacl_to_links(shacl_json: &str, class_name: &str) -> Result<Vec<Li
                 target: format!("literal:string:{}", remover_json),
             });
         }
+
+        // sh:class — target SHACL node shape URI for typed relation resolution
+        if let Some(class_uri) = &prop.class {
+            links.push(Link {
+                source: prop_shape_uri.clone(),
+                predicate: Some("sh://class".to_string()),
+                target: class_uri.clone(),
+            });
+        }
+
+        // Pre-computed getter expression for conformance-filtered relation traversal
+        if let Some(getter) = &prop.getter {
+            links.push(Link {
+                source: prop_shape_uri.clone(),
+                predicate: Some("ad4m://getter".to_string()),
+                target: format!("literal:string:{}", getter),
+            });
+        }
+
+        // Structured conformance conditions for DB-agnostic type filtering
+        if !prop.conformance_conditions.is_empty() {
+            let conditions_json = serde_json::to_string(&prop.conformance_conditions)
+                .unwrap_or_else(|_| "[]".to_string());
+            links.push(Link {
+                source: prop_shape_uri.clone(),
+                predicate: Some("ad4m://conformanceConditions".to_string()),
+                target: format!("literal:string:{}", conditions_json),
+            });
+        }
     }
 
     Ok(links)


### PR DESCRIPTION
# Fix: SHACL `sh:class` Link Emission + `fromSHACL` classResolver

**Branch:** `feat/fromSHACL-class-resolver`  
**Files changed:** 2 (`core/src/model/Ad4mModel.ts`, `rust-executor/src/perspectives/shacl_parser.rs`)

---

## Problem

`$query: { model: 'Channel', include: { messages: true } }` in WE schema templates returned broken hydration — related models were never populated. Tracing the failure revealed two stacked bugs:

1. **`fromSHACL` had no `target` on collection properties** — so `enrichShapeForIncludes` and `jsonToModelInstance` skipped all relation traversal.
2. **Root cause: `sh:class` links were never stored** — even though the JS side generated the correct SHACL JSON (including `class`, `getter`, and `conformanceConditions` fields), the Rust executor silently dropped them when converting SHACL JSON to perspective links.

---

## Root Cause (Rust)

`parse_shacl_to_links` in `rust-executor/src/perspectives/shacl_parser.rs` iterated over each `PropertyShape` and emitted links for `sh:path`, `sh:minCount`, `sh:maxCount`, `sh:datatype`, `sh:in`, `remover`, etc. — but had **no code** to emit:

- `sh://class` (the target node-shape URI for typed relation resolution)
- `ad4m://getter` (the pre-computed expression string used for conformance-filtered traversal)
- `ad4m://conformanceConditions` (the structured type-filter conditions array)

These three fields were present in the `PropertyShape` struct and populated from the JSON, but then discarded when constructing the output `Vec<Link>`.

---

## Fix 1 — Rust: emit missing link types

**File:** `rust-executor/src/perspectives/shacl_parser.rs`

Added three new `links.push(...)` blocks immediately after the existing `remover` block, one for each missing field:

```rust
// sh:class — target SHACL node shape URI for typed relation resolution
if let Some(class_uri) = &prop.class {
    links.push(Link {
        source: prop_shape_uri.clone(),
        predicate: Some("sh://class".to_string()),
        target: class_uri.clone(),
    });
}

// Pre-computed getter expression for conformance-filtered relation traversal
if let Some(getter) = &prop.getter {
    links.push(Link {
        source: prop_shape_uri.clone(),
        predicate: Some("ad4m://getter".to_string()),
        target: format!("literal:string:{}", getter),
    });
}

// Structured conformance conditions for DB-agnostic type filtering
if !prop.conformance_conditions.is_empty() {
    let conditions_json = serde_json::to_string(&prop.conformance_conditions)
        .unwrap_or_else(|_| "[]".to_string());
    links.push(Link {
        source: prop_shape_uri.clone(),
        predicate: Some("ad4m://conformanceConditions".to_string()),
        target: format!("literal:string:{}", conditions_json),
    });
}
```

---

## Fix 2 — TypeScript: `fromSHACL` classResolver parameter

**File:** `core/src/model/Ad4mModel.ts`

Added an optional third parameter `classResolver?: (localName: string) => typeof Ad4mModel | undefined` to `fromSHACL`. When provided, collection properties with a `sh:class` URI get a lazy `target` thunk:

```ts
let targetThunk: (() => typeof Ad4mModel) | undefined;
if (prop.class && classResolver) {
  const sep = Math.max(prop.class.lastIndexOf('#'), prop.class.lastIndexOf('/'));
  const localName = sep >= 0 ? prop.class.slice(sep + 1) : prop.class;
  targetThunk = () => classResolver(localName) as typeof Ad4mModel;
}

setRelationRegistryEntry(DynamicModelClass, prop.name, {
  predicate: prop.path,
  kind: 'hasMany',
  ...(targetThunk !== undefined && { target: targetThunk }),
  ...(prop.local !== undefined && { local: prop.local }),
  ...(prop.getter !== undefined && { getter: prop.getter }),
});
```

The thunk is only evaluated at query time (inside `enrichShapeForIncludes` / `jsonToModelInstance`), so it is safe to pass a closure over a registry that is still being populated — no circular-initialization issues.

**Caller** (`we/packages/app-framework/.../perspectiveHelpers.ts`): passes a `classResolver` that looks up classes by both `"Name"` and `"NameShape"` keys, since the `sh:class` URI local-name follows the `"MessageShape"` convention used by the SHACL node shapes.

---

## Testing

Verified end-to-end in the WE Electron dev app:

- `Channel.all()` returns channels with `messages` array populated with hydrated `Message` instances
- `$query: { model: 'Channel', include: { messages: true } }` in schema templates renders correctly
- Existing queries without `include` are unaffected (backward-compatible — `classResolver` is optional, `targetThunk` is only set when both `prop.class` and `classResolver` are present)

---

## Related WE-side changes (separate repo, separate PR)

The following companion fixes in the `we` repo were required for the full stack to work:

| File | Change |
|------|--------|
| `packages/schema-system/shared/src/types.ts` | Added `include` field to `QueryDescriptor` |
| `packages/schema-system/shared/src/propResolvers/query.ts` | Destructure `include` separately so it isn't spread into filter params |
| `packages/schema-system/frameworks/solid/src/SchemaRenderer.tsx` | Pass `include` to `findAll`/`query` |
| `packages/app-framework/src/frameworks/solid/stores/perspectiveHelpers.ts` | Pass `classResolver` to `fromSHACL`; double-register classes under `"NameShape"` key |
