### PR TITLE
Feature(connect): Replace embedded mode timeout with ACK protocol

### DIFF
--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -384,7 +384,11 @@ export default class Ad4mConnect extends EventTarget {
           // Set connection details from parent (after successful validation)
           this.port = parsedPort;
           this.token = normalizedToken;
-          this.url = `http://localhost:${parsedPort}`;
+          // Use the URL provided by the parent if valid (e.g. remote host), otherwise fall back to localhost
+          const rawUrl = event.data.url;
+          this.url = (rawUrl && typeof rawUrl === 'string' && rawUrl.startsWith('http'))
+            ? rawUrl
+            : `http://localhost:${parsedPort}`;
           
           // Store in localStorage for persistence (avoid storing undefined or stale credentials)
           setLocal('ad4m-port', parsedPort.toString());

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -78,32 +78,49 @@ export default class Ad4mConnect extends EventTarget {
       console.log('[Ad4m Connect] Embedded mode - waiting for AD4M config via postMessage');
       
       return new Promise((resolve, reject) => {
-        // Set up 30 second timeout
-        const timeout = setTimeout(() => {
-          reject(new Error('Timeout waiting for AD4M config from parent window'));
+        // The 30-second timeout only guards waiting for AD4M_CONFIG_ACK — the parent
+        // acknowledging that it received our request and is alive. Once the ACK arrives
+        // we know auth is in progress and we wait indefinitely for the actual AD4M_CONFIG
+        // (the user may take several minutes to complete the auth flow).
+        const ackTimeout = setTimeout(() => {
+          window.removeEventListener('message', handleAck);
+          reject(new Error('Timeout waiting for AD4M_CONFIG_ACK from parent window (is the app running inside we-web?)'));
         }, 30000);
-        
-        // Store resolvers to call when AD4M_CONFIG arrives
+
+        const handleAck = (event: MessageEvent) => {
+          if (event.data?.type === 'AD4M_CONFIG_ACK' && event.source === window.parent) {
+            clearTimeout(ackTimeout);
+            window.removeEventListener('message', handleAck);
+            console.log('[Ad4m Connect] Received AD4M_CONFIG_ACK — parent is alive, waiting for config after auth');
+          }
+        };
+        window.addEventListener('message', handleAck);
+
+        // Store resolvers to call when AD4M_CONFIG arrives (via initializeEmbeddedMode listener)
         this.embeddedResolve = (client: Ad4mClient) => {
-          clearTimeout(timeout);
+          clearTimeout(ackTimeout);
+          window.removeEventListener('message', handleAck);
           console.log('[Ad4m Connect] Successfully connected in embedded mode');
           resolve(client);
         };
         
         this.embeddedReject = (error: Error) => {
-          clearTimeout(timeout);
+          clearTimeout(ackTimeout);
+          window.removeEventListener('message', handleAck);
           reject(error);
         };
         
         // If we already have a client (message arrived before connect() was called)
         if (this.ad4mClient) {
           if (this.authState === 'authenticated') {
-            clearTimeout(timeout);
+            clearTimeout(ackTimeout);
+            window.removeEventListener('message', handleAck);
             console.log('[Ad4m Connect] Client already initialized in embedded mode');
             resolve(this.ad4mClient);
           } else {
             // Auth already failed before connect() was called
-            clearTimeout(timeout);
+            clearTimeout(ackTimeout);
+            window.removeEventListener('message', handleAck);
             reject(new Error(`Embedded auth state: ${this.authState}`));
           }
         }


### PR DESCRIPTION
# Replace embedded mode timeout with ACK protocol

## Problem

When opening we-web for the first time in a browser, Flux (an embedded app running inside a `we-iframe`) would fail to initialise with:

```
Failed to initialize Flux: Error: Timeout waiting for AD4M config from parent window
```

The root cause is a race condition between Flux's 30-second timeout and the we-web auth flow:

1. Flux loads inside the iframe and immediately sends `REQUEST_AD4M_CONFIG` to the parent window
2. `connect()` starts a 30-second countdown
3. we-web cannot send `AD4M_CONFIG` until the user completes the ad4m-connect auth UI — which requires human interaction and can easily take longer than 30 seconds
4. Timeout fires → Flux fails to initialise

Refreshing the page works because the auth token is cached in localStorage, so `AD4M_CONFIG` is sent in milliseconds.

## Solution

Replace the single timeout (measuring "did auth complete in time?") with a two-phase ACK protocol that measures only "is the parent window alive?".

### Phase 1 — ACK (≤30 seconds)

The parent window (we-web) immediately sends `AD4M_CONFIG_ACK` back to the iframe the instant it receives `REQUEST_AD4M_CONFIG` — before auth starts, before any async work. This happens in milliseconds.

`connect()` in embedded mode sets a 30-second timeout waiting only for this ACK. Once it arrives the timeout is cleared and the promise waits indefinitely.

### Phase 2 — Config (unbounded)

After auth completes, we-web sends `AD4M_CONFIG` with the port and token. The `initializeEmbeddedMode` listener resolves the promise and the embedded app initialises normally.

### Failure case

If no `AD4M_CONFIG_ACK` arrives within 30 seconds, the error now reads:

```
Timeout waiting for AD4M_CONFIG_ACK from parent window (is the app running inside we-web?)
```

This accurately describes the only real failure scenario: the embedded app is not running inside we-web at all (e.g. navigated to directly, or the parent crashed before the listener was set up).

## Changes

### `connect/src/core.ts`

**ACK protocol:**
- `connect()` in embedded mode now sets up a `handleAck` listener for `AD4M_CONFIG_ACK` alongside the 30-second `ackTimeout`
- On ACK receipt: timeout cleared, listener removed, promise continues waiting for `AD4M_CONFIG`
- All early-exit paths (`embeddedResolve`, `embeddedReject`, pre-existing client) also clear the timeout and remove the listener

**Remote host URL propagation:**
- The `AD4M_CONFIG` handler previously hardcoded `this.url = http://localhost:{port}`, which broke WebSocket connections when WE was connected to a remote node
- Now uses the `url` field from the `AD4M_CONFIG` message if provided and valid (starts with `http`), falling back to `localhost:{port}` for local connections

## Companion change (we-web)

`AdamStore.tsx` in `packages/app-framework` must also be updated to:

1. Send `AD4M_CONFIG_ACK` immediately on receiving `REQUEST_AD4M_CONFIG`
2. Send the actual `AD4M_CONFIG` as soon as `port` and `token` signals are set (not gated on `bootState === 'ready'`)
3. Include the executor `url` in the `AD4M_CONFIG` message (read from the platform adapter's `getConnectionDetails()` before the signals are set, so effects don't fire before the URL is available)

This is tracked separately in the we-web repo.
