### PR TITLE
Fix: Non-literal property resolution for `findAll` and `subscribe` paths

### DIFF
--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -25,6 +25,46 @@ import type {
 
 
 // ---------------------------------------------------------------------------
+// Default decoder for file-storage (non-literal resolveLanguage) properties
+// ---------------------------------------------------------------------------
+
+/**
+ * When the Rust executor resolves a non-literal expression it may return a
+ * `FileData`-shaped object (`{ data_base64, file_type, ... }`) rather than a
+ * raw URI string.  If the model class has no custom `transform` registered
+ * (e.g. it was synthesised from a SHACL shape at runtime) we still want to
+ * decode the content rather than passing raw `FileData` to callers.
+ *
+ * Decoding rules (mirrors the JS `decodeFileAsJson` / `decodeFileAsString` helpers):
+ *   - `application/json` (default when `file_type` is absent) → JSON.parse
+ *   - anything else                                            → raw decoded string
+ *
+ * If `resolved` is not a `FileData` object the value is returned unchanged so
+ * that callers can use this as a safe unconditional fallback.
+ */
+function defaultFileDecode(resolved: unknown): unknown {
+  if (
+    resolved !== null &&
+    typeof resolved === 'object' &&
+    'data_base64' in (resolved as object)
+  ) {
+    const fd = resolved as { data_base64: string; file_type?: string };
+    let raw: string;
+    try {
+      raw = atob(fd.data_base64);
+    } catch {
+      return resolved; // malformed base64 — keep as-is
+    }
+    const isJson = !fd.file_type || fd.file_type === 'application/json';
+    if (isJson) {
+      try { return JSON.parse(raw); } catch { return raw; }
+    }
+    return raw;
+  }
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers for Rust-side include resolution
 // ---------------------------------------------------------------------------
 
@@ -933,6 +973,60 @@ export class Ad4mModel {
     return arr.map((json: any) => jsonToModelInstance(this, perspective, json, include, properties));
   }
 
+  /**
+   * Resolve non-literal (file-language) properties on an array of already-constructed
+   * model instances.  Handles two cases:
+   *
+   *   1. The Rust executor returned a raw URI string → fetch via `getExpression` then apply transform.
+   *   2. The Rust executor already resolved the expression and returned a `FileData` object
+   *      (happens when the perspective backend eagerly fetches file content) → apply transform
+   *      (or `defaultFileDecode` if no transform is registered on the class, e.g. for SHACL-
+   *      synthesised model classes).
+   *
+   * Extracted as a public static so `ModelQueryBuilder.subscribe()` can reuse it without
+   * duplicating logic or introducing a circular dependency.
+   * @internal
+   */
+  static async resolveNonLiteralProps<T extends Ad4mModel>(
+    this: typeof Ad4mModel & (new (...args: any[]) => T),
+    perspective: PerspectiveProxy,
+    instances: T[],
+  ): Promise<void> {
+    const propsMeta = getPropertiesMetadata(this as any);
+    const resolveProps = Object.entries(propsMeta).filter(
+      ([, opts]: [string, any]) =>
+        opts.resolveLanguage != null &&
+        opts.resolveLanguage !== 'literal',
+    );
+    if (resolveProps.length === 0) return;
+
+    await Promise.all(
+      instances.map(async (inst: any) => {
+        for (const [propName, opts] of resolveProps) {
+          const val = inst[propName];
+          const transform = (opts as any).transform;
+          const applyTransform = (resolved: unknown) =>
+            typeof transform === 'function' ? transform(resolved) : defaultFileDecode(resolved);
+
+          if (typeof val === 'string' && val && !val.startsWith('literal:')) {
+            // Case 1: raw URI — fetch from language runtime
+            try {
+              const expression = await perspective.getExpression(val);
+              if (expression) {
+                let resolved: any;
+                try { resolved = JSON.parse(expression.data); } catch { resolved = expression.data; }
+                inst[propName] = applyTransform(resolved);
+              }
+            } catch (_) { /* resolution failed — keep raw value */ }
+          } else if (val !== null && val !== undefined && typeof val === 'object') {
+            // Case 2: already resolved by Rust — apply transform / default decode
+            inst[propName] = applyTransform(val);
+          }
+        }
+      }),
+    );
+  }
+
   // instancesFromQueryResult — removed (superseded by Rust executeModelQuery pipeline)
 
   /**
@@ -1111,32 +1205,9 @@ export class Ad4mModel {
 
     // Resolve non-literal expressions (e.g. file languages where the stored
     // value is a content-addressed hash that must be fetched from the language
-    // runtime). The Rust endpoint returns raw target URIs; we resolve them here.
-    const propsMeta = getPropertiesMetadata(this as any);
-    const resolveProps = Object.entries(propsMeta).filter(
-      ([, opts]: [string, any]) =>
-        opts.resolveLanguage != null &&
-        opts.resolveLanguage !== 'literal',
-    );
-    if (resolveProps.length > 0) {
-      await Promise.all(
-        instances.map(async (inst: any) => {
-          for (const [propName, opts] of resolveProps) {
-            const val = inst[propName];
-            if (typeof val !== 'string' || !val || val.startsWith('literal:')) continue;
-            try {
-              const expression = await perspective.getExpression(val);
-              if (expression) {
-                let resolved: any;
-                try { resolved = JSON.parse(expression.data); } catch { resolved = expression.data; }
-                const transform = (opts as any).transform;
-                inst[propName] = typeof transform === 'function' ? transform(resolved) : resolved;
-              }
-            } catch (_) { /* resolution failed — keep raw value */ }
-          }
-        }),
-      );
-    }
+    // runtime). The Rust endpoint may return either a raw target URI (string)
+    // or an already-resolved FileData object — both cases are handled here.
+    await (this as any).resolveNonLiteralProps(perspective, instances);
 
     // Take snapshots for dirty tracking
     const snapshotRelations = queryInput.include;

--- a/core/src/model/ModelQueryBuilder.ts
+++ b/core/src/model/ModelQueryBuilder.ts
@@ -391,8 +391,15 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
       return (ctor as any).parseModelResult(this.perspective, raw, this.queryParams.include, this.queryParams.properties);
     };
 
-    // Parse initial results
-    const initialResults = parseResults(initialModelResult);
+    // Resolve non-literal (file-language) properties — handles both raw URI strings
+    // and already-resolved FileData objects returned by the Rust executor.
+    const resolveAndReturn = async (instances: T[]): Promise<T[]> => {
+      await (ctor as any).resolveNonLiteralProps(this.perspective, instances);
+      return instances;
+    };
+
+    // Parse initial results (with non-literal resolution)
+    const initialResults = await resolveAndReturn(parseResults(initialModelResult));
 
     // Track last emitted result fingerprint to suppress duplicate callbacks
     let lastResultFingerprint: string | null = null;
@@ -414,11 +421,14 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
         // data that would overwrite real subscription updates.
         if (rawResult && rawResult.isInit) return;
         try {
-          const results = parseResults(rawResult);
-          const fp = buildFingerprint(results);
-          if (fp === lastResultFingerprint) return;
-          lastResultFingerprint = fp;
-          callback(results);
+          resolveAndReturn(parseResults(rawResult)).then((results) => {
+            const fp = buildFingerprint(results);
+            if (fp === lastResultFingerprint) return;
+            lastResultFingerprint = fp;
+            callback(results);
+          }).catch((e) => {
+            console.error('Model subscription update resolve error:', e);
+          });
         } catch (e) {
           console.error('Model subscription update parse error:', e);
         }


### PR DESCRIPTION
# Fix: Non-literal property resolution for `findAll` and `subscribe` paths

**Branch:** `fix/non-literal-property-transforms`
**Base:** `feat/embedded-ack-protocol`

---

## Background

For model properties with a non-literal `resolveLanguage` (e.g. `FILE_STORAGE_LANGUAGE`), the Rust executor always returns the raw content-addressed URI string (e.g. `QmzS...://QmzS...`) in query results — it never fetches the expression content itself. The JS layer is solely responsible for resolving those URIs:

1. Call `perspective.getExpression(uri)` → receives an `ExpressionRendered` whose `.data` field is the JSON-serialised content (e.g. a `FileData` object: `{ data_base64, file_type, ... }`)
2. Call `JSON.parse(expression.data)` → produces the content object
3. Apply the registered `transform` function (e.g. `decodeFileAsJson`) → produces the final decoded value

This resolution happened in an inline async loop inside `executeModelQuery`, which `findAll` goes through. However, two separate bugs meant the final decoded value was not always reaching callers.

---

## Bugs

### Bug 1 — Wrong model class used for `CollectionBlock` (and any WE-native model)

`getModelForPerspective` in `modelRegistry.ts` checked the *per-perspective* synthesised registry before the global registry. When `setCurrentPerspective` is called, `getAllShacl()` discovers every SHACL shape in the perspective — including those registered by WE itself (e.g. `CollectionBlock`) — and synthesises bare `Ad4mModel` subclasses from them. These synthesised classes carry **no `transform` metadata**, because transforms are TypeScript decorator closures that cannot be encoded in SHACL.

The synthesised `CollectionBlock` class was therefore shadowing the real TypeScript class in the per-perspective registry. When `$query` resolved the model for a `CollectionBlock` query, it got back the synthesised class. The async resolution loop in `executeModelQuery` ran, called `getExpression`, got back the `FileData` object from `JSON.parse(expression.data)`, checked `(opts as any).transform` — found `undefined` — and set `inst.editorState = FileData` directly. The `BlockRenderer` received raw `{ data_base64, ... }` instead of the decoded editor-state JSON.

### Bug 2 — Subscription path never ran the resolution loop at all

`ModelQueryBuilder.subscribe()` called `parseModelResult` → `jsonToModelInstance` to build class instances from the raw Rust JSON, but never ran the async `getExpression` resolution loop. As a result, subscription results always contained the bare raw URI string for any property with a non-literal `resolveLanguage`, regardless of which model class was used or whether a `transform` was registered.

---

## Fixes

### `we` — `packages/app-framework/src/shared/registries/modelRegistry.ts`

`getModelForPerspective` now checks the global (WE-native) registry first and only falls back to the per-perspective synthesised registry for genuinely external models. Native classes always have full decorator metadata; synthesised classes are only correct for models that WE has no compile-time knowledge of.

### `core/src/model/Ad4mModel.ts`

#### `defaultFileDecode` (new module-level helper)

A content-type-aware fallback decoder used when no custom `transform` is registered — i.e. for SHACL-synthesised model classes representing external models (e.g. Flux models). Decoding rules mirror the existing `decodeFileAsJson` / `decodeFileAsString` JS helpers:

- absent `file_type` or `application/json` → `JSON.parse(atob(data_base64))`
- any other `file_type` → `atob(data_base64)` (raw decoded string)
- non-`FileData` input → returned unchanged (safe to use as an unconditional fallback)

This ensures that even models without a registered `transform` — including all dynamically synthesised external models — receive decoded values rather than raw `FileData` objects.

#### `static resolveNonLiteralProps` (new public static method)

Extracts the async expression-resolution loop that previously lived inline in `executeModelQuery` and makes it reusable. For each non-literal property on the class:

- **Raw URI string** → call `perspective.getExpression(val)`, `JSON.parse` the result, apply `transform` (or `defaultFileDecode` as fallback)
- **Already-decoded object on the instance** → apply `transform` or `defaultFileDecode` directly (guards against a stale `FileData` value surviving on a reused instance from a prior call where the transform was missing)

Exposed as a `public static` so `ModelQueryBuilder` can call it without introducing a circular import.

#### `executeModelQuery`

The inline resolution loop is replaced with a single call to `this.resolveNonLiteralProps(perspective, instances)`.

### `core/src/model/ModelQueryBuilder.ts`

`subscribe()` now calls `resolveNonLiteralProps` via a local `resolveAndReturn` helper:

- **Initial results** — `await resolveAndReturn(parseResults(initialModelResult))` before returning to the caller
- **Subscription update callback** — `resolveAndReturn(parseResults(rawResult)).then(callback)` so every push from Rust also goes through resolution before notifying the subscriber

---

## Impact & safety

| Scenario | Before | After |
|---|---|---|
| `findAll`, WE-native class, transform registered | ✅ resolved | ✅ resolved (unchanged) |
| `findAll`, SHACL-synthesised class shadows native (Bug 1) | ❌ raw `FileData` passed to caller | ✅ native class used; transform applied |
| `findAll`, external SHACL-synthesised class, no transform | ❌ raw `FileData` passed to caller | ✅ `defaultFileDecode` applied |
| `subscribe` initial results, any class (Bug 2) | ❌ raw URI string | ✅ resolved; transform or `defaultFileDecode` applied |
| `subscribe` update callbacks, any class (Bug 2) | ❌ raw URI string | ✅ resolved; transform or `defaultFileDecode` applied |

No existing behaviour is removed. Custom `transform` functions always take precedence over `defaultFileDecode`. Properties with `resolveLanguage: 'literal'` are unaffected (excluded from `resolveProps` by the existing filter).