### PR TITLE
Bump SPARQL query timeout from 30s to 60s

### DIFF
--- a/rust-executor/src/api/perspectives_ws.rs
+++ b/rust-executor/src/api/perspectives_ws.rs
@@ -532,7 +532,7 @@ async fn query_prolog(params: Value, ctx: Arc<RequestContext>) -> Result<Value, 
 }
 
 /// Server-side timeout for SPARQL queries (seconds).
-const SPARQL_QUERY_TIMEOUT_SECS: u64 = 30;
+const SPARQL_QUERY_TIMEOUT_SECS: u64 = 60;
 
 async fn query_sparql(params: Value, ctx: Arc<RequestContext>) -> Result<Value, WsRpcError> {
     let uuid = params.require_str("uuid")?;

--- a/rust-executor/src/languages/mod.rs
+++ b/rust-executor/src/languages/mod.rs
@@ -98,16 +98,22 @@ pub struct LanguageController {
 
 impl LanguageController {
     pub fn init_global_instance() {
-        let mut instance = LANGUAGE_CONTROLLER_INSTANCE.lock().unwrap();
+        let mut instance = LANGUAGE_CONTROLLER_INSTANCE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         *instance = Some(LanguageController::new());
     }
 
     pub fn global_instance() -> LanguageController {
-        LANGUAGE_CONTROLLER_INSTANCE
+        let mut instance = LANGUAGE_CONTROLLER_INSTANCE
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner());
+        if instance.is_none() {
+            *instance = Some(LanguageController::new());
+        }
+        instance
             .as_ref()
-            .expect("LanguageController not initialized")
+            .expect("LanguageController initialization failed")
             .clone()
     }
 

--- a/rust-executor/src/languages/mod.rs
+++ b/rust-executor/src/languages/mod.rs
@@ -98,22 +98,16 @@ pub struct LanguageController {
 
 impl LanguageController {
     pub fn init_global_instance() {
-        let mut instance = LANGUAGE_CONTROLLER_INSTANCE
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut instance = LANGUAGE_CONTROLLER_INSTANCE.lock().unwrap();
         *instance = Some(LanguageController::new());
     }
 
     pub fn global_instance() -> LanguageController {
-        let mut instance = LANGUAGE_CONTROLLER_INSTANCE
+        LANGUAGE_CONTROLLER_INSTANCE
             .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        if instance.is_none() {
-            *instance = Some(LanguageController::new());
-        }
-        instance
+            .unwrap()
             .as_ref()
-            .expect("LanguageController initialization failed")
+            .expect("LanguageController not initialized")
             .clone()
     }
 


### PR DESCRIPTION
## Summary

Bump \`SPARQL_QUERY_TIMEOUT_SECS\` from 30s to 60s in [perspectives_ws.rs](rust-executor/src/api/perspectives_ws.rs). Some legitimate queries exceed the 30s budget under load.

Originally bundled with a \`LanguageController\` poison-recovery / lazy-init change, but the lazy-init piece is actually required by [#825](https://github.com/coasys/ad4m/pull/825)'s new \`resolve_language_transforms\` code path and has been moved there. The poison-recovery piece was defensive-only with no concrete incident, so dropped to keep this PR minimal.

## Test plan

- [ ] CI build-and-test passes
- [ ] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)