### PR TITLE
Fix: V8 & Holochain crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1423,7 +1423,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1443,7 +1443,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1463,7 +1463,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2429,7 +2429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2438,7 +2438,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3857,7 +3857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "deno_core"
 version = "0.347.0"
-source = "git+https://github.com/coasys/deno_core.git?branch=new-v8-dylib#f685c89dd2929da2e1001b006a8e4ff8b09b1bf3"
+source = "git+https://github.com/coasys/deno_core.git?branch=new-v8-dylib#0df0b852b1c01f6bf888e9e1f5007655067b7766"
 dependencies = [
  "anyhow",
  "az",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "deno_ops"
 version = "0.223.0"
-source = "git+https://github.com/coasys/deno_core.git?branch=new-v8-dylib#f685c89dd2929da2e1001b006a8e4ff8b09b1bf3"
+source = "git+https://github.com/coasys/deno_core.git?branch=new-v8-dylib#0df0b852b1c01f6bf888e9e1f5007655067b7766"
 dependencies = [
  "indexmap 2.11.1",
  "proc-macro-rules",
@@ -6242,7 +6242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6476,7 +6476,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7298,7 +7298,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -9376,7 +9376,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -10007,7 +10007,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -10050,9 +10050,9 @@ checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10192,7 +10192,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14060,7 +14060,7 @@ dependencies = [
  "sparesults",
  "spareval",
  "spargebra",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -14088,7 +14088,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "ryu-js",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -14103,7 +14103,7 @@ dependencies = [
  "oxsdatatypes",
  "rand 0.9.2",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -14116,7 +14116,7 @@ dependencies = [
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -14129,7 +14129,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -14148,7 +14148,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -14161,7 +14161,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -15564,7 +15564,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15602,9 +15602,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16891,7 +16891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16904,7 +16904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17054,7 +17054,7 @@ dependencies = [
  "security-framework 3.6.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17753,7 +17753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -18062,7 +18062,7 @@ dependencies = [
 [[package]]
 name = "serde_v8"
 version = "0.256.0"
-source = "git+https://github.com/coasys/deno_core.git?branch=new-v8-dylib#f685c89dd2929da2e1001b006a8e4ff8b09b1bf3"
+source = "git+https://github.com/coasys/deno_core.git?branch=new-v8-dylib#0df0b852b1c01f6bf888e9e1f5007655067b7766"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -18631,7 +18631,7 @@ dependencies = [
  "memchr",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -18654,7 +18654,7 @@ dependencies = [
  "sparesults",
  "spargebra",
  "sparopt",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -18668,7 +18668,7 @@ dependencies = [
  "oxrdf",
  "peg",
  "rand 0.9.2",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -19039,6 +19039,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -20648,7 +20649,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -21705,7 +21706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -22253,8 +22254,8 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "137.1.0"
-source = "git+https://github.com/coasys/rusty_v8.git?tag=v137.1.0#c302ece8ab991ce125d29acdacb623a39585b581"
+version = "137.1.1"
+source = "git+https://github.com/coasys/rusty_v8.git?tag=v137.1.1#18dccc49674e228c56f6120cd350f4968967b9f5"
 dependencies = [
  "bindgen 0.71.1",
  "bitflags 2.9.4",
@@ -23262,7 +23263,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust-executor/src/holochain_service/interface.rs
+++ b/rust-executor/src/holochain_service/interface.rs
@@ -290,8 +290,23 @@ lazy_static! {
 }
 
 pub async fn get_holochain_service() -> HolochainServiceInterface {
-    let lock = HOLOCHAIN_SERVICE.read().await;
-    lock.clone().expect("Holochain Conductor not started")
+    // Poll for the conductor to become available, with a timeout.
+    // Language threads may call this before HolochainService::init() has
+    // finished setting the global — instead of panicking immediately we
+    // give the conductor up to 120 seconds to start.
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(120);
+    loop {
+        {
+            let lock = HOLOCHAIN_SERVICE.read().await;
+            if let Some(svc) = lock.clone() {
+                return svc;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("Holochain Conductor not started after 120s timeout");
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    }
 }
 
 pub async fn maybe_get_holochain_service() -> Option<HolochainServiceInterface> {

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -1041,7 +1041,7 @@ mod tests {
             use std::sync::Once;
             static V8_INIT: Once = Once::new();
             V8_INIT.call_once(|| {
-                deno_core::v8::V8::set_flags_from_string("--no-opt");
+                deno_core::v8::V8::set_flags_from_string("--no-opt --no-sparkplug --no-maglev");
                 deno_core::JsRuntime::init_platform(None, false);
             });
         }

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -1041,7 +1041,7 @@ mod tests {
             use std::sync::Once;
             static V8_INIT: Once = Once::new();
             V8_INIT.call_once(|| {
-                deno_core::v8::V8::set_flags_from_string("--no-opt --no-sparkplug --no-maglev");
+                deno_core::v8::V8::set_flags_from_string("--max-opt=0");
                 deno_core::JsRuntime::init_platform(None, false);
             });
         }

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -415,7 +415,7 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
         use std::sync::Once;
         static V8_FLAGS_INIT: Once = Once::new();
         V8_FLAGS_INIT.call_once(|| {
-            deno_core::v8::V8::set_flags_from_string("--no-opt --no-sparkplug --no-maglev");
+            deno_core::v8::V8::set_flags_from_string("--max-opt=0");
             deno_core::JsRuntime::init_platform(None, false);
         });
     }

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -415,7 +415,7 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
         use std::sync::Once;
         static V8_FLAGS_INIT: Once = Once::new();
         V8_FLAGS_INIT.call_once(|| {
-            deno_core::v8::V8::set_flags_from_string("--no-opt");
+            deno_core::v8::V8::set_flags_from_string("--no-opt --no-sparkplug --no-maglev");
             deno_core::JsRuntime::init_platform(None, false);
         });
     }


### PR DESCRIPTION
This updates our V8/Deno fork with a fix (deactivating leaptiering) that resolves segfaults.
Also fixes a race condition around using the Holochain service which also caused occasional crashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved holochain service startup to retry during initialization with an extended timeout for more reliable launches.

* **Tests**
  * Updated V8 engine initialization settings used in tests to align runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coasys/ad4m/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->