### PR TITLE
feat: typed query DSL + remove dead engine plumbing

### DIFF
--- a/ad4m-hooks/react/src/useLiveQuery.ts
+++ b/ad4m-hooks/react/src/useLiveQuery.ts
@@ -3,6 +3,7 @@ import {
   PerspectiveProxy,
   Ad4mModel,
   Query,
+  TypedQuery,
   ParentScope,
   PaginationResult,
   ModelQueryBuilder,
@@ -115,7 +116,11 @@ export function useLiveQuery<T extends Ad4mModel>(
   const [pageNumber, setPageNumber] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
 
-  const modelQueryRef = useRef<ModelQueryBuilder<T | Ad4mModel> | null>(null);
+  // Widened to ModelQueryBuilder<Ad4mModel> because the typed chain methods
+  // (`where`, `order`, `include`) are contravariant in T — invariance prevents
+  // the per-branch `ModelQueryBuilder<T>` / `ModelQueryBuilder<Ad4mModel>` from
+  // unifying directly. Subscribe callbacks cast back to T[] at the boundary.
+  const modelQueryRef = useRef<ModelQueryBuilder<Ad4mModel> | null>(null);
 
   /** Build the full query from user options + pagination + parent + instance filter. */
   function buildQuery(): Query {
@@ -137,12 +142,18 @@ export function useLiveQuery<T extends Ad4mModel>(
     return q;
   }
 
-  /** Build a ModelQueryBuilder for either a class constructor or a string class name. */
-  function makeQueryBuilder(q: Query) {
+  /** Build a ModelQueryBuilder for either a class constructor or a string class name.
+   *  The cast to `TypedQuery<T>` is necessary because the hook is generic over an
+   *  arbitrary `T extends Ad4mModel` — TypeScript can't statically resolve whether
+   *  T has typed fields, so the deferred `TypedQuery<T>` conditional doesn't accept
+   *  the raw `Query` shape we build at runtime. End-user callers of the static API
+   *  retain strict typing; this cast is the documented escape hatch for generic
+   *  meta-utilities that build queries dynamically. */
+  function makeQueryBuilder(q: Query): ModelQueryBuilder<Ad4mModel> {
     if (typeof model === "string") {
-      return Ad4mModel.query(perspective, q).overrideModelClassName(model);
+      return Ad4mModel.query(perspective, q as TypedQuery<Ad4mModel>).overrideModelClassName(model);
     }
-    return (model as ModelCtor<T>).query(perspective, q);
+    return (model as ModelCtor<T>).query(perspective, q as TypedQuery<T>) as unknown as ModelQueryBuilder<Ad4mModel>;
   }
 
   function mergeEntries(oldEntries: T[], newEntries: T[]): T[] {

--- a/ad4m-hooks/vue/src/useLiveQuery.ts
+++ b/ad4m-hooks/vue/src/useLiveQuery.ts
@@ -4,6 +4,7 @@ import {
   PaginationResult,
   PerspectiveProxy,
   Query,
+  TypedQuery,
   ParentScope,
 } from "@coasys/ad4m";
 import {
@@ -125,7 +126,11 @@ export function useLiveQuery<T extends Ad4mModel>(
   const error = ref<string>("");
   const pageNumber = ref(1);
   const totalCount = ref(0);
-  let modelQuery: ModelQueryBuilder<T | Ad4mModel> | null = null;
+  // Widened to ModelQueryBuilder<Ad4mModel> because the typed chain methods
+  // (`where`, `order`, `include`) are contravariant in T — invariance prevents
+  // the per-branch `ModelQueryBuilder<T>` / `ModelQueryBuilder<Ad4mModel>` from
+  // unifying directly. Subscribe callbacks cast back to T[] at the boundary.
+  let modelQuery: ModelQueryBuilder<Ad4mModel> | null = null;
 
   // Normalise: accept either a raw PerspectiveProxy or a ref/computed wrapping one
   const perspectiveRef = shallowRef<PerspectiveProxy | null>(
@@ -160,12 +165,18 @@ export function useLiveQuery<T extends Ad4mModel>(
     return q;
   }
 
-  /** Build a ModelQueryBuilder for either a class constructor or a string class name. */
-  function makeQueryBuilder(q: Query, p: PerspectiveProxy) {
+  /** Build a ModelQueryBuilder for either a class constructor or a string class name.
+   *  The cast to `TypedQuery<T>` is necessary because the hook is generic over an
+   *  arbitrary `T extends Ad4mModel` — TypeScript can't statically resolve whether
+   *  T has typed fields, so the deferred `TypedQuery<T>` conditional doesn't accept
+   *  the raw `Query` shape we build at runtime. End-user callers of the static API
+   *  retain strict typing; this cast is the documented escape hatch for generic
+   *  meta-utilities that build queries dynamically. */
+  function makeQueryBuilder(q: Query, p: PerspectiveProxy): ModelQueryBuilder<Ad4mModel> {
     if (typeof model === "string") {
-      return Ad4mModel.query(p, q).overrideModelClassName(model);
+      return Ad4mModel.query(p, q as TypedQuery<Ad4mModel>).overrideModelClassName(model);
     }
-    return (model as ModelCtor<T>).query(p, q);
+    return (model as ModelCtor<T>).query(p, q as TypedQuery<T>) as unknown as ModelQueryBuilder<Ad4mModel>;
   }
 
   function mergeEntries(oldEntries: T[], newEntries: T[]): T[] {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -16,6 +16,7 @@ export * from "./Literal";
 export * from "./perspectives/Perspective";
 export * from "./perspectives/PerspectiveHandle";
 export * from "./perspectives/PerspectiveProxy";
+export * from "./perspectives/SparqlBindings";
 export * from "./perspectives/WakerSubscriptionManager";
 export * from "./perspectives/PerspectiveDiff";
 export * from "./perspectives/LinkQuery";

--- a/core/src/model/Ad4mModel.test.ts
+++ b/core/src/model/Ad4mModel.test.ts
@@ -645,8 +645,7 @@ describe("Ad4mModel query methods (modelQuery integration)", () => {
     jest.clearAllMocks();
   });
 
-  it("should use SPARQL when engine is 'sparql' in findAll()", async () => {
-    // modelQuery returns already-hydrated instances from the Rust executor
+  it("routes findAll() through modelQuery", async () => {
     mockPerspective.modelQuery.mockResolvedValue({
       instances: [
         { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
@@ -654,27 +653,12 @@ describe("Ad4mModel query methods (modelQuery integration)", () => {
       totalCount: 1
     });
 
-    const results = await Recipe.findAll(mockPerspective, {}, 'sparql');
+    const results = await Recipe.findAll(mockPerspective);
 
     expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
     expect(mockPerspective.infer).not.toHaveBeenCalled();
     expect(results).toHaveLength(1);
     expect(results[0].name).toBe("Pasta");
-  });
-
-  it("should route through modelQuery when engine is 'prolog' in findAll() (prolog is now no-op)", async () => {
-    mockPerspective.modelQuery.mockResolvedValue({
-      instances: [
-        { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
-      ],
-      totalCount: 1
-    });
-
-    const results = await Recipe.findAll(mockPerspective, {}, false);
-    
-    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
-    expect(mockPerspective.infer).not.toHaveBeenCalled();
-    expect(results).toHaveLength(1);
   });
 
   it("should use SPARQL when engine is 'sparql' in findAllAndCount()", async () => {
@@ -737,7 +721,7 @@ describe("Ad4mModel query methods (modelQuery integration)", () => {
     expect(count).toBe(10);
   });
 
-  it("should use SPARQL when engine is 'sparql' in ModelQueryBuilder.get()", async () => {
+  it("routes ModelQueryBuilder.get() through modelQuery", async () => {
     mockPerspective.modelQuery.mockResolvedValue({
       instances: [
         { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
@@ -747,7 +731,6 @@ describe("Ad4mModel query methods (modelQuery integration)", () => {
 
     const results = await Recipe.query(mockPerspective)
       .where({ name: "Pasta" })
-      .engine('sparql')
       .get();
 
     expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
@@ -756,26 +739,7 @@ describe("Ad4mModel query methods (modelQuery integration)", () => {
     expect(results[0].name).toBe("Pasta");
   });
 
-  it("should use modelQuery when .engine('prolog') is called (engine is now a no-op)", async () => {
-    mockPerspective.modelQuery.mockResolvedValue({
-      instances: [
-        { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
-      ],
-      totalCount: 1
-    });
-
-    const results = await Recipe.query(mockPerspective)
-      .where({ name: "Pasta" })
-      .engine('prolog')
-      .get();
-    
-    // engine('prolog') is now a no-op — everything goes through modelQuery
-    expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
-    expect(mockPerspective.infer).not.toHaveBeenCalled();
-    expect(results).toHaveLength(1);
-  });
-
-  it("should use SPARQL when engine is 'sparql' in ModelQueryBuilder.count()", async () => {
+  it("routes ModelQueryBuilder.count() through modelQuery", async () => {
     mockPerspective.modelQuery.mockResolvedValue({
       instances: [],
       totalCount: 3
@@ -783,7 +747,6 @@ describe("Ad4mModel query methods (modelQuery integration)", () => {
 
     const count = await Recipe.query(mockPerspective)
       .where({ rating: { gt: 4 } })
-      .engine('sparql')
       .count();
 
     expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
@@ -791,7 +754,7 @@ describe("Ad4mModel query methods (modelQuery integration)", () => {
     expect(count).toBe(3);
   });
 
-  it("should use SPARQL when engine is 'sparql' in ModelQueryBuilder.paginate()", async () => {
+  it("routes ModelQueryBuilder.paginate() through modelQuery", async () => {
     mockPerspective.modelQuery.mockResolvedValue({
       instances: [
         { id: "literal:recipe1", name: "Pasta", rating: 5, ingredients: ["pasta"] }
@@ -801,7 +764,6 @@ describe("Ad4mModel query methods (modelQuery integration)", () => {
 
     const page = await Recipe.query(mockPerspective)
       .where({ rating: { gt: 3 } })
-      .engine('sparql')
       .paginate(10, 1);
 
     expect(mockPerspective.modelQuery).toHaveBeenCalledTimes(1);
@@ -917,7 +879,6 @@ describe("Ad4mModel.count() with advanced where conditions", () => {
     // Count recipes with rating > 3 using ModelQueryBuilder
     const count = await Recipe.query(mockPerspective)
       .where({ rating: { gt: 3 } })
-      .engine('sparql')
       .count();
     
     expect(count).toBe(2);
@@ -936,7 +897,6 @@ describe("Ad4mModel.count() with advanced where conditions", () => {
     // Count using ModelQueryBuilder
     const count = await Recipe.query(mockPerspective)
       .where({ timestamp: { between: [startTimestamp, endTimestamp] } })
-      .engine('sparql')
       .count();
     
     expect(count).toBe(3);

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -21,6 +21,7 @@ import type {
   GetOptions, AllInstancesResult, ResultsWithTotalCount,
   PaginationResult, PropertyMetadata, RelationMetadata, ModelMetadata,
   IncludeProjection,
+  TypedQuery, IncludeExtras, IncludeOf,
 } from "./types";
 
 
@@ -1139,19 +1140,18 @@ export class Ad4mModel {
    * });
    * ```
    */
-  static async findAll<T extends Ad4mModel>(
+  static async findAll<T extends Ad4mModel, Q extends TypedQuery<T> = {}>(
     this: typeof Ad4mModel & (new (...args: any[]) => T),
     perspective: PerspectiveProxy,
-    query: Query = {},
-    /** @deprecated Ignored — Prolog engine has been removed. */
-    _engine?: 'sparql' | 'prolog' | boolean
-  ): Promise<T[]> {
-    if (query.properties && query.properties.length === 0) {
+    query?: Q,
+  ): Promise<(T & IncludeExtras<T, IncludeOf<Q>>)[]> {
+    const q = (query ?? {}) as Query;
+    if (q.properties && q.properties.length === 0) {
       throw new Error("properties[] must not be empty — omit the field to return all properties, or specify at least one field name");
     }
 
-    const { results } = await this.executeModelQuery(perspective, query);
-    return results;
+    const { results } = await this.executeModelQuery(perspective, q);
+    return results as (T & IncludeExtras<T, IncludeOf<Q>>)[];
   }
 
   /**
@@ -1174,15 +1174,13 @@ export class Ad4mModel {
    * }
    * ```
    */
-  static async findOne<T extends Ad4mModel>(
+  static async findOne<T extends Ad4mModel, Q extends TypedQuery<T> = {}>(
     this: typeof Ad4mModel & (new (...args: any[]) => T),
     perspective: PerspectiveProxy,
-    query: Query = {},
-    /** @deprecated Ignored — Prolog engine has been removed. */
-    _engine?: 'sparql' | 'prolog' | boolean,
-  ): Promise<T | null> {
-    const limitedQuery = { ...query, limit: 1 };
-    const results = await this.findAll(perspective, limitedQuery);
+    query?: Q,
+  ): Promise<(T & IncludeExtras<T, IncludeOf<Q>>) | null> {
+    const limitedQuery = { ...((query ?? {}) as Query), limit: 1 } as Q;
+    const results = await this.findAll<T, Q>(perspective, limitedQuery);
     return results[0] ?? null;
   }
 
@@ -1203,14 +1201,13 @@ export class Ad4mModel {
    * console.log(`Showing 10 of ${totalCount} dessert recipes`);
    * ```
    */
-  static async findAllAndCount<T extends Ad4mModel>(
+  static async findAllAndCount<T extends Ad4mModel, Q extends TypedQuery<T> = {}>(
     this: typeof Ad4mModel & (new (...args: any[]) => T),
     perspective: PerspectiveProxy,
-    query: Query = {},
-    /** @deprecated Ignored — Prolog engine has been removed. */
-    _engine?: 'sparql' | 'prolog' | boolean
-  ): Promise<ResultsWithTotalCount<T>> {
-    return await this.executeModelQuery(perspective, query);
+    query?: Q,
+  ): Promise<ResultsWithTotalCount<T & IncludeExtras<T, IncludeOf<Q>>>> {
+    const out = await this.executeModelQuery(perspective, (query ?? {}) as Query);
+    return out as ResultsWithTotalCount<T & IncludeExtras<T, IncludeOf<Q>>>;
   }
 
   /**
@@ -1230,18 +1227,16 @@ export class Ad4mModel {
    * console.log(`Page ${page.pageNumber} of recipes, ${page.results.length} items`);
    * ```
    */
-  static async paginate<T extends Ad4mModel>(
+  static async paginate<T extends Ad4mModel, Q extends TypedQuery<T> = {}>(
     this: typeof Ad4mModel & (new (...args: any[]) => T),
     perspective: PerspectiveProxy,
     pageSize: number,
     pageNumber: number,
-    query?: Query,
-    /** @deprecated Ignored — Prolog engine has been removed. */
-    _engine?: 'sparql' | 'prolog' | boolean
-  ): Promise<PaginationResult<T>> {
-    const paginationQuery = { ...(query || {}), limit: pageSize, offset: pageSize * (pageNumber - 1), count: true };
+    query?: Q,
+  ): Promise<PaginationResult<T & IncludeExtras<T, IncludeOf<Q>>>> {
+    const paginationQuery = { ...((query ?? {}) as Query), limit: pageSize, offset: pageSize * (pageNumber - 1), count: true };
     const { results, totalCount } = await this.executeModelQuery(perspective, paginationQuery);
-    return { results, totalCount, pageSize, pageNumber };
+    return { results: results as (T & IncludeExtras<T, IncludeOf<Q>>)[], totalCount, pageSize, pageNumber };
   }
 
   /**
@@ -1270,8 +1265,12 @@ export class Ad4mModel {
    * });
    * ```
    */
-  static async count(perspective: PerspectiveProxy, query: Query = {}): Promise<number> {
-    const { totalCount } = await this.executeModelQuery(perspective, { ...query, limit: 0 });
+  static async count<T extends Ad4mModel>(
+    this: typeof Ad4mModel & (new (...args: any[]) => T),
+    perspective: PerspectiveProxy,
+    query?: TypedQuery<T>,
+  ): Promise<number> {
+    const { totalCount } = await this.executeModelQuery(perspective, { ...((query ?? {}) as Query), limit: 0 });
     return totalCount;
   }
 
@@ -2067,11 +2066,11 @@ export class Ad4mModel {
    * ```
    */
   static query<T extends Ad4mModel>(
-    this: typeof Ad4mModel & (new (...args: any[]) => T), 
-    perspective: PerspectiveProxy, 
-    query?: Query
+    this: typeof Ad4mModel & (new (...args: any[]) => T),
+    perspective: PerspectiveProxy,
+    query?: TypedQuery<T>,
   ): ModelQueryBuilder<T> {
-    return new ModelQueryBuilder<T>(perspective, this as any, query);
+    return new ModelQueryBuilder<T>(perspective, this as any, (query ?? {}) as Query);
   }
 
   /**

--- a/core/src/model/ModelQueryBuilder.ts
+++ b/core/src/model/ModelQueryBuilder.ts
@@ -10,6 +10,7 @@ import type { PerspectiveProxy } from "../perspectives/PerspectiveProxy";
 import type {
   Where, Order, IncludeMap, Query,
   ResultsWithTotalCount, PaginationResult,
+  TypedWhere, TypedOrder, TypedIncludeMap, PropertyKeysOf,
 } from "./types";
 
 /** Query builder for Ad4mModel queries.
@@ -80,8 +81,8 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    * })
    * ```
    */
-  where(conditions: Where): ModelQueryBuilder<T> {
-    this.queryParams.where = conditions;
+  where(conditions: TypedWhere<T>): ModelQueryBuilder<T> {
+    this.queryParams.where = conditions as Where;
     return this;
   }
 
@@ -96,8 +97,8 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    * .order({ createdAt: "DESC" })
    * ```
    */
-  order(orderBy: Order): ModelQueryBuilder<T> {
-    this.queryParams.order = orderBy;
+  order(orderBy: TypedOrder<T>): ModelQueryBuilder<T> {
+    this.queryParams.order = orderBy as Order;
     return this;
   }
 
@@ -218,8 +219,8 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    * .properties(["name", "description", "rating"])
    * ```
    */
-  properties(properties: string[]): ModelQueryBuilder<T> {
-    this.queryParams.properties = properties;
+  properties(properties: PropertyKeysOf<T>[] | string[]): ModelQueryBuilder<T> {
+    this.queryParams.properties = properties as string[];
     return this;
   }
 
@@ -272,21 +273,13 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    *   .run();
    * ```
    */
-  include(map: IncludeMap): ModelQueryBuilder<T> {
-    this.queryParams.include = map;
+  include(map: TypedIncludeMap<T>): ModelQueryBuilder<T> {
+    this.queryParams.include = map as IncludeMap;
     return this;
   }
 
   overrideModelClassName(className: string): ModelQueryBuilder<T> {
     this.modelClassName = className;
-    return this;
-  }
-
-  /**
-   * Sets the query engine to use.
-   * @deprecated Prolog engine has been removed. All queries use SPARQL/Rust.
-   */
-  engine(_eng: 'sparql' | 'prolog'): ModelQueryBuilder<T> {
     return this;
   }
 

--- a/core/src/model/types-typed-query.test.ts
+++ b/core/src/model/types-typed-query.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Type-level assertion tests for the TypedQuery / TypedWhere / TypedIncludeMap
+ * surface added in PLAN_6.
+ *
+ * These tests verify the *compile-time* behaviour of the generic query types.
+ * Runtime assertions are minimal — the real checks are the `// @ts-expect-error`
+ * markers and the `expectAssignable` / `expectExact` helpers, all of which fail
+ * loudly under `tsc --noEmit`.
+ */
+
+import { Ad4mModel } from "./Ad4mModel";
+import { Model, Property, HasMany, BelongsToOne } from "./decorators";
+import type {
+  PropertyKeysOf, RelationKeysOf, RelatedModel,
+  TypedQuery, TypedWhere, TypedOrder, TypedIncludeMap, TypedIncludeProjection,
+  IncludeExtras, Query,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+@Model({ name: "Comment" })
+class Comment extends Ad4mModel {
+  @Property({ through: "comment://text" })
+  text: string = "";
+
+  @Property({ through: "comment://likes" })
+  likes: number = 0;
+}
+
+@Model({ name: "Post" })
+class Post extends Ad4mModel {
+  @Property({ through: "post://title", required: true })
+  title: string = "";
+
+  @Property({ through: "post://body" })
+  body: string = "";
+
+  @Property({ through: "post://is_pinned" })
+  isPinned: boolean = false;
+
+  @Property({ through: "post://views" })
+  views: number = 0;
+
+  @HasMany(() => Comment, { through: "post://comment" })
+  comments: Comment[] = [];
+
+  @BelongsToOne({ through: "post://author_of" })
+  authorRef: Comment | null = null;
+}
+
+// AgentProfile-like fixture: inheritance + optional HasOne relation.
+// This mirrors `we/packages/models/src/entities/AgentProfile.ts` which
+// previously surfaced a type bug in StrictTypedIncludeMap.
+class WeNodeLike extends Ad4mModel {
+  @HasMany({ through: "we://signal" })
+  signals: string[] = [];
+}
+
+class LocationBlockLike extends WeNodeLike {
+  @Property({ through: "loc://name" })
+  name: string = "";
+}
+
+@Model({ name: "AgentProfileLike" })
+class AgentProfileLike extends WeNodeLike {
+  @Property({ through: "we://handle" })
+  handle: string = "";
+
+  @Property({ through: "we://avatar" })
+  avatar?: string;
+
+  // Optional HasOne — Ad4mModel | undefined. Was previously not picked up
+  // by RelationKeysOf (which only checked `| null`), causing valid
+  // `include: { location: true }` calls to be rejected at the type level.
+  location?: LocationBlockLike;
+}
+
+// ---------------------------------------------------------------------------
+// Type-level helpers
+// ---------------------------------------------------------------------------
+
+type Equals<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends
+  (<T>() => T extends Y ? 1 : 2) ? true : false;
+
+function expectExact<T1, T2>(_: Equals<T1, T2> extends true ? true : never): void {}
+function expectAssignable<T>(_: T): void {}
+
+// ---------------------------------------------------------------------------
+// PropertyKeysOf / RelationKeysOf
+// ---------------------------------------------------------------------------
+
+type PostProps = PropertyKeysOf<Post>;
+type PostRels  = RelationKeysOf<Post>;
+
+expectExact<PostProps, "title" | "body" | "isPinned" | "views">(true);
+expectExact<PostRels,  "comments" | "authorRef">(true);
+
+expectExact<RelatedModel<Post, "comments">, Comment>(true);
+expectExact<RelatedModel<Post, "authorRef">, Comment>(true);
+
+// AgentProfileLike — inheritance + optional HasOne via `?: T`
+type AgentRels = RelationKeysOf<AgentProfileLike>;
+type AgentProps = PropertyKeysOf<AgentProfileLike>;
+
+// `location?: LocationBlockLike` (i.e. `LocationBlockLike | undefined`) must
+// be recognised as a relation. `signals: string[]` inherited from WeNodeLike
+// also counts (the `@HasMany` + `string[]` pattern).
+expectAssignable<AgentRels>("location");
+expectAssignable<AgentRels>("signals");
+expectAssignable<AgentProps>("handle");
+expectAssignable<AgentProps>("avatar");
+
+expectAssignable<TypedIncludeMap<AgentProfileLike>>({ location: true });
+expectAssignable<TypedIncludeMap<AgentProfileLike>>({ signals: true });
+
+// ---------------------------------------------------------------------------
+// TypedWhere
+// ---------------------------------------------------------------------------
+
+// Valid where shapes
+expectAssignable<TypedWhere<Post>>({ title: "hello" });
+expectAssignable<TypedWhere<Post>>({ title: { contains: "x" } });
+expectAssignable<TypedWhere<Post>>({ views: { gt: 5, lte: 100 } });
+expectAssignable<TypedWhere<Post>>({ isPinned: true });
+expectAssignable<TypedWhere<Post>>({ id: "literal:foo" });
+expectAssignable<TypedWhere<Post>>({ author: "did:key:alice" });
+
+// Misspelled property — must error
+// @ts-expect-error
+expectAssignable<TypedWhere<Post>>({ titel: "hello" });
+
+// Wrong value type — must error
+// @ts-expect-error
+expectAssignable<TypedWhere<Post>>({ isPinned: "yes" });
+
+// Numeric op on string field — must error
+// @ts-expect-error
+expectAssignable<TypedWhere<Post>>({ title: { gt: 5 } });
+
+// String op on numeric field — must error
+// @ts-expect-error
+expectAssignable<TypedWhere<Post>>({ views: { contains: "x" } });
+
+// ---------------------------------------------------------------------------
+// TypedOrder
+// ---------------------------------------------------------------------------
+
+expectAssignable<TypedOrder<Post>>({ title: "ASC" });
+expectAssignable<TypedOrder<Post>>({ views: "DESC", timestamp: "ASC" });
+
+// @ts-expect-error — unknown field
+expectAssignable<TypedOrder<Post>>({ titel: "ASC" });
+
+// @ts-expect-error — invalid direction
+expectAssignable<TypedOrder<Post>>({ title: "ASCENDING" });
+
+// ---------------------------------------------------------------------------
+// TypedIncludeMap — eager-load + nested
+// ---------------------------------------------------------------------------
+
+expectAssignable<TypedIncludeMap<Post>>({ comments: true });
+expectAssignable<TypedIncludeMap<Post>>({ authorRef: true });
+expectAssignable<TypedIncludeMap<Post>>({
+  comments: { where: { text: "x" }, order: { likes: "DESC" }, limit: 5 },
+});
+
+// Misspelled relation — must error
+// @ts-expect-error
+expectAssignable<TypedIncludeMap<Post>>({ commments: true });
+
+// Nested where typo — must error
+// @ts-expect-error
+expectAssignable<TypedIncludeMap<Post>>({ comments: { where: { txet: "x" } } });
+
+// Nested numeric op on string — must error
+// @ts-expect-error
+expectAssignable<TypedIncludeMap<Post>>({ comments: { where: { text: { gt: 5 } } } });
+
+// ---------------------------------------------------------------------------
+// TypedIncludeProjection ($-prefixed keys)
+// ---------------------------------------------------------------------------
+
+// Valid: count true projection
+expectAssignable<TypedIncludeMap<Post>>({
+  $commentCount: { from: "comments", count: true },
+});
+
+// Valid: filtered projection with limit
+expectAssignable<TypedIncludeMap<Post>>({
+  $firstComment: { from: "comments", where: { text: "hi" }, limit: 1 },
+});
+
+// `from` must reference a real relation
+{
+  const _bad1: TypedIncludeMap<Post> = {
+    $bogus: {
+      // @ts-expect-error — "notARelation" is not in RelationKeysOf<Post>
+      from: "notARelation",
+      count: true,
+    },
+  };
+  void _bad1;
+}
+
+// Projection's nested where uses the *target's* property keys
+expectAssignable<TypedIncludeMap<Post>>({
+  $popular: { from: "comments", where: { likes: { gt: 100 } }, limit: 10 },
+});
+
+// Wrong nested where key on the target
+{
+  const _bad2: TypedIncludeMap<Post> = {
+    $bad: {
+      from: "comments",
+      // @ts-expect-error — "titel" is not a property of Comment
+      where: { titel: "x" },
+    },
+  };
+  void _bad2;
+}
+
+// ---------------------------------------------------------------------------
+// IncludeExtras — propagating $-keys into the row type
+// ---------------------------------------------------------------------------
+
+type CountProjection = { $commentCount: { from: "comments"; count: true } };
+type Limit1Projection = { $firstComment: { from: "comments"; limit: 1 } };
+type ListProjection = { $allComments: { from: "comments" } };
+
+expectExact<IncludeExtras<Post, CountProjection>["$commentCount"], number>(true);
+expectExact<IncludeExtras<Post, Limit1Projection>["$firstComment"], Comment | null>(true);
+expectExact<IncludeExtras<Post, ListProjection>["$allComments"], Comment[]>(true);
+
+// ---------------------------------------------------------------------------
+// TypedQuery — full shape
+// ---------------------------------------------------------------------------
+
+expectAssignable<TypedQuery<Post>>({
+  where: { isPinned: true, views: { gt: 10 } },
+  order: { views: "DESC" },
+  include: { comments: { limit: 5 }, $commentCount: { from: "comments", count: true } },
+  includeAll: false,
+  deepQuery: true,
+  limit: 20,
+  offset: 0,
+  count: true,
+  properties: ["title", "body"],
+});
+
+// @ts-expect-error — properties[] only accepts declared property names
+expectAssignable<TypedQuery<Post>>({ properties: ["title", "nonsense"] });
+
+// ---------------------------------------------------------------------------
+// fromSHACL escape hatch — TypedQuery<Ad4mModel> collapses to loose Query
+// ---------------------------------------------------------------------------
+
+// When T has no declared fields (i.e. Ad4mModel itself), TypedQuery<T> ≡ Query.
+expectExact<TypedQuery<Ad4mModel>, Query>(true);
+expectAssignable<TypedQuery<Ad4mModel>>({ where: { anyKey: "value" } });
+
+// ---------------------------------------------------------------------------
+// End-to-end inference through findAll / findOne — verifies that the literal
+// `count: true` propagates through `Q extends TypedQuery<T>` into the return
+// type so callers don't need `(row as any).$xxx` casts.
+// ---------------------------------------------------------------------------
+
+import type { PerspectiveProxy } from "../perspectives/PerspectiveProxy";
+declare const persp: PerspectiveProxy;
+
+// Skip async actually-running them — these calls are unreachable at runtime
+// (no perspective). The point is that they compile with correct return types.
+function _typeFlowChecks() {
+  return async () => {
+    // No include — plain Post[]
+    const a = await Post.findAll(persp);
+    expectAssignable<Post[]>(a);
+
+    // Include eager-loaded relation — still Post[]
+    const b = await Post.findAll(persp, { include: { comments: true } });
+    expectAssignable<Post[]>(b);
+
+    // Projection: count → number on result rows
+    const c = await Post.findAll(persp, {
+      include: { $commentCount: { from: "comments", count: true } },
+    });
+    expectAssignable<number>(c[0].$commentCount);
+
+    // Projection: limit 1 → scalar | null on result rows
+    const d = await Post.findAll(persp, {
+      include: { $top: { from: "comments", limit: 1 } },
+    });
+    expectAssignable<Comment | null>(d[0].$top);
+
+    // Projection: no limit → array on result rows
+    const e = await Post.findAll(persp, {
+      include: { $all: { from: "comments" } },
+    });
+    expectAssignable<Comment[]>(e[0].$all);
+
+    // findOne — same propagation, nullable wrapper
+    const f = await Post.findOne(persp, {
+      include: { $commentCount: { from: "comments", count: true } },
+    });
+    if (f) expectAssignable<number>(f.$commentCount);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runtime placeholder — Jest requires at least one test in the file
+// ---------------------------------------------------------------------------
+
+describe("typed-query types (compile-time)", () => {
+  it("compiles", () => {
+    // All assertions above are at type level; this test passes if tsc passed.
+    expect(true).toBe(true);
+  });
+});

--- a/core/src/model/types-typed-query.test.ts
+++ b/core/src/model/types-typed-query.test.ts
@@ -77,6 +77,29 @@ class AgentProfileLike extends WeNodeLike {
   location?: LocationBlockLike;
 }
 
+// Optional-array fixture: covers `?: T[]` and `?: string[]` patterns. Before
+// the `NonNullable<T[K]> extends X[]` change, these optional array relations
+// were silently dropped from RelationKeysOf because `Foo[] | undefined extends
+// Foo[]` evaluates to false.
+@Model({ name: "OptionalArrayLike" })
+class OptionalArrayLike extends Ad4mModel {
+  @Property({ through: "x://name" })
+  name: string = "";
+
+  // Optional typed-array relation
+  @HasMany(() => Comment, { through: "x://comments" })
+  comments?: Comment[];
+
+  // Optional string[] relation (the `@HasMany` + `string[]` pattern)
+  @HasMany({ through: "x://members" })
+  members?: string[];
+
+  // Optional scalar array — also `string[] | undefined`, should appear as a
+  // relation too (matches the runtime semantics: any array field can be a
+  // link collection unless we have stronger schema info).
+  tags?: string[];
+}
+
 // ---------------------------------------------------------------------------
 // Type-level helpers
 // ---------------------------------------------------------------------------
@@ -115,6 +138,23 @@ expectAssignable<AgentProps>("avatar");
 
 expectAssignable<TypedIncludeMap<AgentProfileLike>>({ location: true });
 expectAssignable<TypedIncludeMap<AgentProfileLike>>({ signals: true });
+
+// Optional-array regression: `comments?: Comment[]`, `members?: string[]`,
+// `tags?: string[]` should all be recognised as relations. Previously
+// rejected because `T[K] = T[] | undefined` doesn't extend `T[]`.
+type OptArrRels = RelationKeysOf<OptionalArrayLike>;
+expectAssignable<OptArrRels>("comments");
+expectAssignable<OptArrRels>("members");
+expectAssignable<OptArrRels>("tags");
+
+expectAssignable<TypedIncludeMap<OptionalArrayLike>>({ comments: true });
+expectAssignable<TypedIncludeMap<OptionalArrayLike>>({ members: true });
+expectAssignable<TypedIncludeMap<OptionalArrayLike>>({
+  $commentCount: { from: "comments", count: true },
+});
+
+// RelatedModel must also peel the optional wrapper before inferring U
+expectExact<RelatedModel<OptionalArrayLike, "comments">, Comment>(true);
 
 // ---------------------------------------------------------------------------
 // TypedWhere

--- a/core/src/model/types.ts
+++ b/core/src/model/types.ts
@@ -149,6 +149,195 @@ export type Query = {
  */
 export type RelationSubQuery = Omit<Query, 'parent' | 'count'>;
 
+// ---------------------------------------------------------------------------
+// Typed Query DSL — Phase 1 of PLAN_6_TYPED_QUERIES.md
+//
+// These types layer compile-time field-name and value-type checking on top of
+// the loose Query/Where/Order/IncludeMap. They infer everything from the
+// model class's declared TS fields — no codegen, no runtime changes.
+//
+// Dynamic models (e.g. produced by `Ad4mModel.fromSHACL()`) carry no
+// field-level type information; for those `TypedQuery<Ad4mModel>` collapses
+// to the loose `Query` shape, which is the correct escape hatch.
+// ---------------------------------------------------------------------------
+
+/** Keys of T that are user-declared (not methods, not inherited from Ad4mModel). */
+export type ModelDataKeys<T extends Ad4mModel> = {
+  [K in keyof T]: K extends keyof Ad4mModel ? never
+    : T[K] extends (...args: any[]) => any ? never
+    : K
+}[keyof T];
+
+/** Keys of T that can appear in a `where` clause — scalars and scalar arrays.
+ *  Excludes typed Ad4mModel references (single or array); `string[]`/`number[]`
+ *  remain included because they're often filterable even when also used as
+ *  link targets.
+ *
+ *  Iterates over `keyof T` directly (not `ModelDataKeys<T>`) to preserve the
+ *  key constraint — mapped types over computed type aliases sometimes widen
+ *  to `string | undefined` in the key position, which then breaks indexing. */
+export type PropertyKeysOf<T extends Ad4mModel> = {
+  [K in keyof T]: K extends ModelDataKeys<T>
+    ? NonNullable<T[K]> extends Ad4mModel ? never
+      : T[K] extends Ad4mModel[] ? never
+      : K
+    : never
+}[keyof T];
+
+/** Keys of T that can appear in `include` — typed Ad4mModel references AND
+ *  `string[]` link-target arrays (the `@HasMany` + `string[]` pattern that
+ *  AD4M uses for relations without a target class thunk). Handles both
+ *  `?: Foo` (optional → `Foo | undefined`) and `Foo | null` field shapes. */
+export type RelationKeysOf<T extends Ad4mModel> = {
+  [K in keyof T]: K extends ModelDataKeys<T>
+    ? NonNullable<T[K]> extends Ad4mModel ? K
+      : T[K] extends Ad4mModel[] ? K
+      : T[K] extends string[] ? K
+      : never
+    : never
+}[keyof T];
+
+/** The model type referenced by a relation field K on T.
+ *  Falls back to `Ad4mModel` (loose) for the `string[]` relation pattern,
+ *  since no target class is available at the type level. */
+export type RelatedModel<T extends Ad4mModel, K extends RelationKeysOf<T>> =
+    T[K] extends (infer U)[] ? (U extends Ad4mModel ? U : Ad4mModel)
+  : NonNullable<T[K]> extends Ad4mModel ? NonNullable<T[K]>
+  : Ad4mModel;
+
+/** True when T has no statically-declared data fields (e.g. fromSHACL classes). */
+type HasNoTypedFields<T extends Ad4mModel> =
+  [PropertyKeysOf<T> | RelationKeysOf<T>] extends [never] ? true : false;
+
+// ---- Typed where conditions --------------------------------------------------
+
+export type StringWhereOps = {
+  not?: string | string[];
+  contains?: string;
+};
+
+export type NumericWhereOps = {
+  not?: number | number[];
+  lt?: number;
+  lte?: number;
+  gt?: number;
+  gte?: number;
+  between?: [number, number];
+};
+
+export type TypedWhereCondition<V> =
+    V extends string  ? string | string[] | StringWhereOps
+  : V extends number  ? number | number[] | NumericWhereOps
+  : V extends boolean ? boolean
+  : V extends Array<infer U>
+      ? U extends string ? string | string[] | StringWhereOps
+        : U extends number ? number | number[] | NumericWhereOps
+        : WhereCondition
+  : WhereCondition;
+
+/** Strict Where: keys constrained to T's properties, plus the well-known
+ *  link-metadata fields (`id`/`author`/`timestamp`). */
+type StrictTypedWhere<T extends Ad4mModel> =
+  & { [K in PropertyKeysOf<T>]?: TypedWhereCondition<T[K]> }
+  & {
+      base?: string | string[];
+      id?: string | string[];
+      author?: WhereCondition;
+      timestamp?: WhereCondition;
+    };
+
+/** Public typed `where` for a model class. Falls back to the loose `Where`
+ *  shape when T has no declared fields (e.g. fromSHACL-derived classes). */
+export type TypedWhere<T extends Ad4mModel> =
+  HasNoTypedFields<T> extends true ? Where : StrictTypedWhere<T>;
+
+// ---- Typed order -------------------------------------------------------------
+
+type StrictTypedOrder<T extends Ad4mModel> = {
+  [K in PropertyKeysOf<T> | 'timestamp' | 'author' | 'createdAt' | 'updatedAt']?: 'ASC' | 'DESC';
+};
+
+export type TypedOrder<T extends Ad4mModel> =
+  HasNoTypedFields<T> extends true ? Order : StrictTypedOrder<T>;
+
+// ---- Typed include + projection ---------------------------------------------
+
+/** Sub-query for an eager-loaded relation — inherits the target model's constraints. */
+export type TypedRelationSubQuery<U extends Ad4mModel> = {
+  where?: TypedWhere<U>;
+  order?: TypedOrder<U>;
+  include?: TypedIncludeMap<U>;
+  limit?: number;
+  offset?: number;
+};
+
+/** Projection — `from` must be a real relation on T; `where`/`order` constrained to that target.
+ *  Modelled as a discriminated union so the literal `count: true` and `limit: 1`
+ *  variants narrow inference into `IncludeExtras` (count → number, limit-1 → scalar). */
+export type TypedIncludeProjection<T extends Ad4mModel> = {
+  [K in RelationKeysOf<T>]:
+    | { from: K; count: true }
+    | { from: K; limit: 1; where?: TypedWhere<RelatedModel<T, K>>; order?: TypedOrder<RelatedModel<T, K>> }
+    | { from: K; limit?: number; where?: TypedWhere<RelatedModel<T, K>>; order?: TypedOrder<RelatedModel<T, K>> };
+}[RelationKeysOf<T>];
+
+type StrictTypedIncludeMap<T extends Ad4mModel> =
+  & { [K in RelationKeysOf<T>]?: boolean | TypedRelationSubQuery<RelatedModel<T, K>> }
+  & { [K in `$${string}`]?: TypedIncludeProjection<T> };
+
+export type TypedIncludeMap<T extends Ad4mModel> =
+  HasNoTypedFields<T> extends true ? IncludeMap : StrictTypedIncludeMap<T>;
+
+// ---- Result-side: project $-keys into the returned row type ------------------
+
+/**
+ * Given a model T and an `include` literal I, compute the extra fields
+ * contributed by `$`-prefixed projection keys.
+ *
+ * - `{ count: true }`           → `number`
+ * - `{ from: R, limit: 1 }`     → `RelatedModel<T,R> | null`
+ * - `{ from: R }` (no limit/1)  → `RelatedModel<T,R>[]`
+ *
+ * Returns `unknown` (intersection-neutral) when `I` has no `$`-keys, so that
+ * `T & IncludeExtras<T, I>` collapses back to `T` and downstream type
+ * predicates (`(x): x is T => ...`) keep working unchanged.
+ */
+export type IncludeExtras<T extends Ad4mModel, I> =
+  I extends Record<string, any>
+    ? Extract<keyof I, `$${string}`> extends never
+      ? unknown
+      : {
+          [K in Extract<keyof I, `$${string}`>]:
+              I[K] extends { count: true } ? number
+            : I[K] extends { from: infer R; limit: 1 }
+                ? (R extends RelationKeysOf<T> ? RelatedModel<T, R> | null : never)
+            : I[K] extends { from: infer R }
+                ? (R extends RelationKeysOf<T> ? RelatedModel<T, R>[] : never)
+            : unknown;
+        }
+    : unknown;
+
+// ---- Typed Query -------------------------------------------------------------
+
+type StrictTypedQuery<T extends Ad4mModel> = {
+  parent?: ParentScope;
+  properties?: PropertyKeysOf<T>[];
+  include?: TypedIncludeMap<T>;
+  includeAll?: boolean;
+  where?: TypedWhere<T>;
+  order?: TypedOrder<T>;
+  offset?: number;
+  limit?: number;
+  count?: boolean;
+  deepQuery?: boolean;
+};
+
+export type TypedQuery<T extends Ad4mModel> =
+  HasNoTypedFields<T> extends true ? Query : StrictTypedQuery<T>;
+
+/** Helper that extracts the `include` literal from a TypedQuery for use with IncludeExtras. */
+export type IncludeOf<Q> = Q extends { include?: infer I } ? I : undefined;
+
 /**
  * Options accepted by the instance `get()` method.
  *

--- a/core/src/model/types.ts
+++ b/core/src/model/types.ts
@@ -179,7 +179,7 @@ export type ModelDataKeys<T extends Ad4mModel> = {
 export type PropertyKeysOf<T extends Ad4mModel> = {
   [K in keyof T]: K extends ModelDataKeys<T>
     ? NonNullable<T[K]> extends Ad4mModel ? never
-      : T[K] extends Ad4mModel[] ? never
+      : NonNullable<T[K]> extends Ad4mModel[] ? never
       : K
     : never
 }[keyof T];
@@ -187,12 +187,13 @@ export type PropertyKeysOf<T extends Ad4mModel> = {
 /** Keys of T that can appear in `include` — typed Ad4mModel references AND
  *  `string[]` link-target arrays (the `@HasMany` + `string[]` pattern that
  *  AD4M uses for relations without a target class thunk). Handles both
- *  `?: Foo` (optional → `Foo | undefined`) and `Foo | null` field shapes. */
+ *  `?: Foo` (optional → `Foo | undefined`) and `Foo | null` field shapes, and
+ *  optional/nullable array variants (`?: Foo[]`, `Foo[] | null`). */
 export type RelationKeysOf<T extends Ad4mModel> = {
   [K in keyof T]: K extends ModelDataKeys<T>
     ? NonNullable<T[K]> extends Ad4mModel ? K
-      : T[K] extends Ad4mModel[] ? K
-      : T[K] extends string[] ? K
+      : NonNullable<T[K]> extends Ad4mModel[] ? K
+      : NonNullable<T[K]> extends string[] ? K
       : never
     : never
 }[keyof T];
@@ -201,7 +202,7 @@ export type RelationKeysOf<T extends Ad4mModel> = {
  *  Falls back to `Ad4mModel` (loose) for the `string[]` relation pattern,
  *  since no target class is available at the type level. */
 export type RelatedModel<T extends Ad4mModel, K extends RelationKeysOf<T>> =
-    T[K] extends (infer U)[] ? (U extends Ad4mModel ? U : Ad4mModel)
+    NonNullable<T[K]> extends (infer U)[] ? (U extends Ad4mModel ? U : Ad4mModel)
   : NonNullable<T[K]> extends Ad4mModel ? NonNullable<T[K]>
   : Ad4mModel;
 

--- a/core/src/perspectives/PerspectiveClient.ts
+++ b/core/src/perspectives/PerspectiveClient.ts
@@ -116,9 +116,9 @@ export class PerspectiveClient {
         return JSON.parse(result)
     }
 
-    async querySparql(uuid: string, query: string): Promise<unknown> {
+    async querySparql<T = unknown>(uuid: string, query: string): Promise<T> {
         const result = await this.#apiClient.call<string>('perspective.querySparql', { uuid, engine: 'sparql', query })
-        return JSON.parse(result)
+        return JSON.parse(result) as T
     }
 
     async subscribeQuery(uuid: string, query: string): Promise<{ subscriptionId: string, result: AllInstancesResult }> {

--- a/core/src/perspectives/PerspectiveClient.ts
+++ b/core/src/perspectives/PerspectiveClient.ts
@@ -116,7 +116,7 @@ export class PerspectiveClient {
         return JSON.parse(result)
     }
 
-    async querySparql<T = unknown>(uuid: string, query: string): Promise<T> {
+    async querySparql<T = any>(uuid: string, query: string): Promise<T> {
         const result = await this.#apiClient.call<string>('perspective.querySparql', { uuid, engine: 'sparql', query })
         return JSON.parse(result) as T
     }

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -589,12 +589,12 @@ export class PerspectiveProxy {
      * @param query - SPARQL query string
      * @returns Query results as parsed JSON
      */
-    async querySparql(query: string): Promise<any> {
+    async querySparql<T = any>(query: string): Promise<T> {
         const cached = getCachedResult(this.#handle.uuid, query);
-        if (cached !== undefined) return cached;
+        if (cached !== undefined) return cached as T;
         const result = await this.#client.querySparql(this.#handle.uuid, query);
         setCachedResult(this.#handle.uuid, query, result);
-        return result;
+        return result as T;
     }
 
     /**

--- a/core/src/perspectives/SparqlBindings.ts
+++ b/core/src/perspectives/SparqlBindings.ts
@@ -1,0 +1,79 @@
+/**
+ * SPARQL binding helpers — typed shapes and parsers for `querySparql<T>()`.
+ *
+ * AD4M stores non-string property values as URL-encoded `Literal` payloads
+ * (see {@link Literal}). When raw SPARQL queries pull these values out of the
+ * RDF store the bindings are still in encoded form; consumers must decode
+ * before use. The helpers here centralise that decode step so each call site
+ * can pick the variant matching its declared binding type.
+ *
+ * @example
+ * ```ts
+ * interface MessageBinding {
+ *   id: string;
+ *   timestamp: string;  // raw literal — decode with parseLitNumber
+ *   body?: string;      // raw literal — decode with parseLit
+ * }
+ * const rows = await perspective.querySparql<MessageBinding[]>(query);
+ * const ts = parseLitNumber(rows[0].timestamp);   // number
+ * const body = rows[0].body ? parseLit(rows[0].body) : '';
+ * ```
+ */
+
+import { Literal } from "../Literal";
+
+/** Common AD4M link binding — matches the `?source/?predicate/?target/?author/?timestamp` pattern. */
+export interface LinkBinding {
+  source: string;
+  predicate: string;
+  target: string;
+  author?: string;
+  timestamp?: string;
+}
+
+/** COUNT(?x) result binding — SPARQL returns counts as string literals. */
+export interface CountBinding {
+  count: string;
+}
+
+/** Sum a SPARQL COUNT(?x) result down to a plain number (returns 0 on empty). */
+export function parseSparqlCount(result: CountBinding[] | undefined | null): number {
+  if (!result || result.length === 0) return 0;
+  const raw = result[0].count;
+  const n = parseInt(raw, 10);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+/**
+ * Decode a `Literal`-encoded SPARQL binding back to a plain string.
+ *
+ * Mirrors Flux's local `parseLit` helper. Returns `''` for `undefined`/empty
+ * input. Falls through to the raw value if decoding fails (defensive — the
+ * binding may already be a plain string for unwrapped properties).
+ */
+export function parseLit(val: string | undefined | null): string {
+  if (val === undefined || val === null || val === '') return '';
+  try {
+    const result = Literal.fromUrl(val).get();
+    if (result && typeof result === 'object') {
+      return (result as { data?: string }).data ?? JSON.stringify(result);
+    }
+    return String(result);
+  } catch {
+    return val;
+  }
+}
+
+/** Decode a `Literal`-encoded binding to a number. Returns 0 on empty/invalid input. */
+export function parseLitNumber(val: string | undefined | null): number {
+  if (val === undefined || val === null || val === '') return 0;
+  const decoded = parseLit(val);
+  const n = Number(decoded);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+/** Decode a `Literal`-encoded binding to a boolean. Returns false on empty input. */
+export function parseLitBoolean(val: string | undefined | null): boolean {
+  if (val === undefined || val === null || val === '') return false;
+  return parseLit(val) === 'true';
+}


### PR DESCRIPTION
## Summary

Implements [`.specs/PLAN_6_TYPED_QUERIES.md`](https://github.com/coasys/ad4m/blob/feat/typed-queries/.specs/PLAN_6_TYPED_QUERIES.md) — the type-system half of the SPARQL 1.2 cleanup arc.

- **Typed query DSL** — `TypedQuery<T>` / `TypedWhere<T>` / `TypedOrder<T>` / `TypedIncludeMap<T>` infer compile-time constraints from each model's declared TS fields. No codegen, no runtime changes. Misspelled property/relation names, wrong value types, and string ops on numeric fields all become compile errors.
- **`$`-projection result inference** — `IncludeExtras<T,I>` propagates `$`-prefixed include keys into the result row type. `{ $signalCount: { from: 'signals', count: true } }` types `row.$signalCount` as `number`; `limit: 1` projections type as `T | null`; otherwise `T[]`. Closes the `(row as any).$x` gap We's docs were living with.
- **`fromSHACL` escape hatch** — `TypedQuery<Ad4mModel>` collapses to the loose `Query` shape automatically, so dynamic models (`Ad4mModel.fromSHACL`) opt out of strict typing by design.
- **Dead engine plumbing removed** — `_engine?` param dropped from `findAll`/`findOne`/`findAllAndCount`/`paginate` and `ModelQueryBuilder.engine()` deleted. Zero call sites in Flux or We pass these; the runtime already ignored them. Test fixtures updated.
- **`querySparql<T>` generic** — `PerspectiveProxy.querySparql` and `PerspectiveClient.querySparql` accept an optional binding type (default `any`).
- **New `SparqlBindings.ts`** — typed `parseLit` / `parseLitNumber` / `parseLitBoolean` / `parseSparqlCount` + `LinkBinding` / `CountBinding` interfaces for raw-SPARQL consumers.

Companion PRs:
- coasys/flux — typed bindings for the ~12 raw SPARQL methods, replaces local `parseLit` with the core re-export
- jhweir/we — doc updates for `$`-projection examples (drops `as any` and `count: true as const` workarounds)

## Test plan

- [x] `npx tsc --noEmit` clean (only pre-existing `AIClient.ts` error remains)
- [x] `npx jest --forceExit` — **434 tests pass** across 15 suites
- [x] New `core/src/model/types-typed-query.test.ts` adds 30+ compile-time assertions (`@ts-expect-error` markers on typos / wrong types, `expectExact`/`expectAssignable` on inference shapes, end-to-end inference through `findAll`/`findOne`)
- [x] Rebuilt `connect` (per CLAUDE.md), verified consumers (Flux api, We app-framework) type-check against the new types

## Notes for reviewers

- The mapped types iterate `[K in keyof T]` (not `[K in ModelDataKeys<T>]`) and re-narrow inside — works around a TS 4.9 quirk where complex computed type aliases collapsed to `string | undefined` in the key position, breaking relation extraction for the `AgentProfile`-shaped optional-HasOne pattern.
- The discriminated `TypedIncludeProjection<T>` union (`{count: true} | {limit: 1} | {limit?: number}`) is what preserves literal narrowing under TS 4.9 — `<const Q>` (TS 5.0+) would be cleaner but isn't available here.
- `_engine` removal is a breaking change at the *type* level only — the runtime ignored it. Surface in the release notes for any out-of-monorepo SDK consumer that was passing the positional arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated Ad4mModel query methods (findAll, findOne, findAllAndCount, paginate, count, query) with improved type signatures and removed deprecated parameters
  * Removed deprecated engine() method from ModelQueryBuilder
  * Enhanced query parameter typing for where, order, properties, and include operations

* **New Features**
  * Added SPARQL binding utilities for parsing query results with type-safe helper functions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coasys/ad4m/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->