### PR TITLE
feat: add postMessage WebSocket proxy for embedded app support

### DIFF
--- a/connect/src/PostMessageFetch.ts
+++ b/connect/src/PostMessageFetch.ts
@@ -1,0 +1,98 @@
+/**
+ * Proxies an HTTP fetch request through window.parent via postMessage.
+ *
+ * Used in embedded proxy mode where the iframe cannot reach the AD4M executor
+ * directly (e.g. when hosted on a different origin inside WE).  The parent
+ * receives the AD4M_PROXY_HTTP_REQUEST message, performs the real fetch, and
+ * replies with AD4M_PROXY_HTTP_RESPONSE / AD4M_PROXY_HTTP_ERROR.
+ *
+ * The request URL may use the placeholder origin 'http://proxy' — the parent
+ * replaces it with the real executor base URL before fetching.
+ */
+
+let _idCounter = 0;
+
+/** Timeout (ms) waiting for the parent to respond to a proxied HTTP request. */
+const PROXY_FETCH_TIMEOUT_MS = 60_000;
+
+/**
+ * Serialise a HeadersInit value to a plain Record so it survives structured
+ * cloning through postMessage.
+ */
+function serialiseHeaders(headers: HeadersInit | undefined): Record<string, string> {
+    if (!headers) return {};
+    if (headers instanceof Headers) {
+        const out: Record<string, string> = {};
+        headers.forEach((v, k) => { out[k] = v; });
+        return out;
+    }
+    if (Array.isArray(headers)) {
+        return Object.fromEntries(headers);
+    }
+    return { ...(headers as Record<string, string>) };
+}
+
+export function makePostMessageFetch(targetOrigin: string): typeof fetch {
+    return async function postMessageFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        const method = init?.method ?? 'GET';
+        const headers = serialiseHeaders(init?.headers);
+        const id = String(++_idCounter);
+
+        // Extract body as a transferable ArrayBuffer when possible.
+        let bodyBuffer: ArrayBuffer | null = null;
+        if (init?.body instanceof ArrayBuffer) {
+            // Slice to avoid transferring a larger shared buffer.
+            const b = init.body as ArrayBuffer;
+            bodyBuffer = b.slice(0);
+        }
+
+        return new Promise<Response>((resolve, reject) => {
+            let timer: ReturnType<typeof setTimeout> | null = null;
+
+            const cleanup = () => {
+                window.removeEventListener('message', handler);
+                if (timer) clearTimeout(timer);
+            };
+
+            const handler = (event: MessageEvent) => {
+                if (event.source !== window.parent) return;
+                if (event.origin !== targetOrigin) return;
+                if (!event.data || event.data.id !== id) return;
+
+                if (event.data.type === 'AD4M_PROXY_HTTP_RESPONSE') {
+                    cleanup();
+                    const { status, statusText, body } = event.data as {
+                        status: number;
+                        statusText: string;
+                        body: ArrayBuffer | null;
+                    };
+                    resolve(new Response(body ?? null, { status, statusText }));
+                    return;
+                }
+
+                if (event.data.type === 'AD4M_PROXY_HTTP_ERROR') {
+                    cleanup();
+                    reject(new TypeError((event.data as { message?: string }).message || 'Failed to fetch'));
+                    return;
+                }
+            };
+
+            window.addEventListener('message', handler);
+
+            timer = setTimeout(() => {
+                cleanup();
+                reject(new TypeError(`AD4M proxy HTTP request timed out after ${PROXY_FETCH_TIMEOUT_MS}ms`));
+            }, PROXY_FETCH_TIMEOUT_MS);
+
+            const msg = { type: 'AD4M_PROXY_HTTP_REQUEST', id, url, method, headers };
+
+            if (bodyBuffer) {
+                // Transfer the buffer zero-copy; the parent receives it as an ArrayBuffer.
+                window.parent.postMessage({ ...msg, body: bodyBuffer }, targetOrigin, [bodyBuffer]);
+            } else {
+                window.parent.postMessage({ ...msg, body: null }, targetOrigin);
+            }
+        });
+    };
+}

--- a/connect/src/PostMessageWebSocket.ts
+++ b/connect/src/PostMessageWebSocket.ts
@@ -23,6 +23,9 @@ export class PostMessageWebSocket {
     onclose:   ((e: CloseEvent) => void) | null = null
 
     private readonly _messageHandler: (e: MessageEvent) => void
+    private _connectTimeout: ReturnType<typeof setTimeout> | null = null
+
+    static readonly CONNECT_TIMEOUT_MS = 30_000
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     constructor(_url: string) {
@@ -33,6 +36,7 @@ export class PostMessageWebSocket {
             if (!msg || typeof msg.type !== 'string') return
 
             if (msg.type === 'AD4M_PROXY_WS_OPEN') {
+                this._clearConnectTimeout()
                 this.readyState = 1
                 this.onopen?.(new Event('open'))
                 return
@@ -42,10 +46,12 @@ export class PostMessageWebSocket {
                 return
             }
             if (msg.type === 'AD4M_PROXY_WS_ERROR') {
+                this._clearConnectTimeout()
                 this.onerror?.(new Event('error'))
                 return
             }
             if (msg.type === 'AD4M_PROXY_WS_CLOSED') {
+                this._clearConnectTimeout()
                 this.readyState = 3
                 this.onclose?.(
                     new CloseEvent('close', {
@@ -60,6 +66,21 @@ export class PostMessageWebSocket {
 
         window.addEventListener('message', this._messageHandler)
         window.parent.postMessage({ type: 'AD4M_PROXY_WS_CONNECT' }, '*')
+
+        this._connectTimeout = setTimeout(() => {
+            this._connectTimeout = null
+            window.removeEventListener('message', this._messageHandler)
+            this.readyState = 3
+            this.onerror?.(new Event('error'))
+            this.onclose?.(new CloseEvent('close', { code: 1006, reason: 'Connection timeout', wasClean: false }))
+        }, PostMessageWebSocket.CONNECT_TIMEOUT_MS)
+    }
+
+    private _clearConnectTimeout(): void {
+        if (this._connectTimeout !== null) {
+            clearTimeout(this._connectTimeout)
+            this._connectTimeout = null
+        }
     }
 
     send(data: string): void {

--- a/connect/src/PostMessageWebSocket.ts
+++ b/connect/src/PostMessageWebSocket.ts
@@ -33,6 +33,9 @@ export class PostMessageWebSocket {
         this._targetOrigin = targetOrigin
         this._messageHandler = (e: MessageEvent) => {
             if (e.source !== window.parent) return
+            // Pin to the origin we verified at connection setup — rejects frames
+            // from a parent that has navigated to a different origin since then.
+            if (e.origin !== this._targetOrigin) return
 
             const msg = e.data
             if (!msg || typeof msg.type !== 'string') return

--- a/connect/src/PostMessageWebSocket.ts
+++ b/connect/src/PostMessageWebSocket.ts
@@ -24,11 +24,13 @@ export class PostMessageWebSocket {
 
     private readonly _messageHandler: (e: MessageEvent) => void
     private _connectTimeout: ReturnType<typeof setTimeout> | null = null
+    private readonly _targetOrigin: string
 
     static readonly CONNECT_TIMEOUT_MS = 30_000
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    constructor(_url: string) {
+    constructor(_url: string, targetOrigin: string) {
+        this._targetOrigin = targetOrigin
         this._messageHandler = (e: MessageEvent) => {
             if (e.source !== window.parent) return
 
@@ -65,7 +67,7 @@ export class PostMessageWebSocket {
         }
 
         window.addEventListener('message', this._messageHandler)
-        window.parent.postMessage({ type: 'AD4M_PROXY_WS_CONNECT' }, '*')
+        window.parent.postMessage({ type: 'AD4M_PROXY_WS_CONNECT' }, this._targetOrigin)
 
         this._connectTimeout = setTimeout(() => {
             this._connectTimeout = null
@@ -84,12 +86,12 @@ export class PostMessageWebSocket {
     }
 
     send(data: string): void {
-        window.parent.postMessage({ type: 'AD4M_PROXY_WS_SEND', data }, '*')
+        window.parent.postMessage({ type: 'AD4M_PROXY_WS_SEND', data }, this._targetOrigin)
     }
 
     close(code?: number, reason?: string): void {
         this.readyState = 2 // CLOSING
-        window.parent.postMessage({ type: 'AD4M_PROXY_WS_CLOSE', code, reason }, '*')
+        window.parent.postMessage({ type: 'AD4M_PROXY_WS_CLOSE', code, reason }, this._targetOrigin)
         window.removeEventListener('message', this._messageHandler)
     }
 }

--- a/connect/src/PostMessageWebSocket.ts
+++ b/connect/src/PostMessageWebSocket.ts
@@ -1,0 +1,74 @@
+/**
+ * A WebSocket-compatible class that proxies all communication through
+ * window.parent via postMessage instead of opening a real WebSocket.
+ *
+ * Used in embedded mode when the host/parent application sends AD4M_CONFIG
+ * with proxy: true. The host opens a real WebSocket to the AD4M daemon and
+ * forwards raw frames bidirectionally via the AD4M_PROXY_WS_* protocol.
+ *
+ * The constructor URL is intentionally ignored — the connection target is
+ * determined by the host, not the embedded app.
+ */
+export class PostMessageWebSocket {
+    static readonly CONNECTING = 0
+    static readonly OPEN = 1
+    static readonly CLOSING = 2
+    static readonly CLOSED = 3
+
+    readyState: number = 0 // CONNECTING
+
+    onopen:    ((e: Event) => void) | null = null
+    onmessage: ((e: MessageEvent) => void) | null = null
+    onerror:   ((e: Event) => void) | null = null
+    onclose:   ((e: CloseEvent) => void) | null = null
+
+    private readonly _messageHandler: (e: MessageEvent) => void
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_url: string) {
+        this._messageHandler = (e: MessageEvent) => {
+            if (e.source !== window.parent) return
+
+            const msg = e.data
+            if (!msg || typeof msg.type !== 'string') return
+
+            if (msg.type === 'AD4M_PROXY_WS_OPEN') {
+                this.readyState = 1
+                this.onopen?.(new Event('open'))
+                return
+            }
+            if (msg.type === 'AD4M_PROXY_WS_MESSAGE') {
+                this.onmessage?.(new MessageEvent('message', { data: msg.data }))
+                return
+            }
+            if (msg.type === 'AD4M_PROXY_WS_ERROR') {
+                this.onerror?.(new Event('error'))
+                return
+            }
+            if (msg.type === 'AD4M_PROXY_WS_CLOSED') {
+                this.readyState = 3
+                this.onclose?.(
+                    new CloseEvent('close', {
+                        code: typeof msg.code === 'number' ? msg.code : 1000,
+                        reason: typeof msg.reason === 'string' ? msg.reason : '',
+                        wasClean: true,
+                    })
+                )
+                window.removeEventListener('message', this._messageHandler)
+            }
+        }
+
+        window.addEventListener('message', this._messageHandler)
+        window.parent.postMessage({ type: 'AD4M_PROXY_WS_CONNECT' }, '*')
+    }
+
+    send(data: string): void {
+        window.parent.postMessage({ type: 'AD4M_PROXY_WS_SEND', data }, '*')
+    }
+
+    close(code?: number, reason?: string): void {
+        this.readyState = 2 // CLOSING
+        window.parent.postMessage({ type: 'AD4M_PROXY_WS_CLOSE', code, reason }, '*')
+        window.removeEventListener('message', this._messageHandler)
+    }
+}

--- a/connect/src/PostMessageWebSocket.ts
+++ b/connect/src/PostMessageWebSocket.ts
@@ -52,7 +52,10 @@ export class PostMessageWebSocket {
             }
             if (msg.type === 'AD4M_PROXY_WS_ERROR') {
                 this._clearConnectTimeout()
+                this.readyState = PostMessageWebSocket.CLOSED
+                window.removeEventListener('message', this._messageHandler)
                 this.onerror?.(new Event('error'))
+                this.onclose?.(new CloseEvent('close', { code: 1006, reason: 'WebSocket error', wasClean: false }))
                 return
             }
             if (msg.type === 'AD4M_PROXY_WS_CLOSED') {

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -347,8 +347,21 @@ export default class Ad4mConnect extends EventTarget {
           return;
         }
 
-        // Verify origin is in allowlist (if configured)
-        if (this.options.allowedOrigins && this.options.allowedOrigins.length > 0) {
+        // Verify origin is in allowlist (if configured).
+        // In proxy mode the parent sees ALL GraphQL traffic, so the allowlist is the
+        // only gate against a malicious site embedding this app — enforce it strictly.
+        if (event.data.proxy) {
+          if (!this.options.allowedOrigins || this.options.allowedOrigins.length === 0) {
+            console.error('[Ad4m Connect] proxy mode requires allowedOrigins to be configured. Rejecting AD4M_CONFIG to prevent arbitrary sites from embedding this app.');
+            this.rejectEmbedded(new Error('proxy mode requires allowedOrigins'));
+            return;
+          }
+          if (!event.origin || !this.options.allowedOrigins.includes(event.origin)) {
+            console.warn('[Ad4m Connect] Rejected AD4M_CONFIG from unauthorized origin:', event.origin);
+            this.rejectEmbedded(new Error(`Unauthorized origin: ${event.origin}`));
+            return;
+          }
+        } else if (this.options.allowedOrigins && this.options.allowedOrigins.length > 0) {
           if (!event.origin || !this.options.allowedOrigins.includes(event.origin)) {
             console.warn('[Ad4m Connect] Rejected AD4M_CONFIG from unauthorized origin:', event.origin);
             this.rejectEmbedded(new Error(`Unauthorized origin: ${event.origin}`));

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -377,12 +377,23 @@ export default class Ad4mConnect extends EventTarget {
               removeLocal('ad4m-token');
             }
 
+            // Use the verified origin of the AD4M_CONFIG sender so postMessage
+            // frames are never delivered to an unexpected parent origin.
+            // Refuse to proceed if the origin is opaque (sandboxed iframe without
+            // allow-same-origin) — falling back to '*' would re-introduce the
+            // wildcard vulnerability for sensitive JSON-RPC frames.
+            if (!event.origin || event.origin === 'null') {
+              throw new Error('AD4M proxy mode requires a non-opaque parent origin. Ensure the host iframe is not sandboxed without allow-same-origin.');
+            }
+            const parentOrigin = event.origin;
+            const wsImpl = (url: string) => new PostMessageWebSocket(url, parentOrigin);
+
             this.notifyConnectionChange('connecting');
             this.ad4mClient = new Ad4mClient(
               'http://proxy', // URL ignored by PostMessageWebSocket
               normalizedToken,
               false,          // defer subscriptions until auth confirmed
-              { webSocketImpl: PostMessageWebSocket as unknown as new (url: string) => WebSocket }
+              { webSocketImpl: wsImpl as unknown as new (url: string) => WebSocket }
             );
             this.notifyConnectionChange('connected');
             await this.checkAuth();

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -1,4 +1,5 @@
 import { isEmbedded, setLocal, getLocal, removeLocal, checkConnection, wsUrlToHttpBase } from './utils';
+import { PostMessageWebSocket } from './PostMessageWebSocket';
 import { Ad4mClient, VerificationRequestResult } from "@coasys/ad4m";
 import autoBind from "auto-bind";
 
@@ -355,11 +356,47 @@ export default class Ad4mConnect extends EventTarget {
           }
         }
 
-        console.log('[Ad4m Connect] Received AD4M_CONFIG from parent:', { port: event.data.port, hasToken: !!event.data.token });
+        console.log('[Ad4m Connect] Received AD4M_CONFIG from parent:', { port: event.data.port, hasToken: !!event.data.token, proxy: !!event.data.proxy });
         
+        // Validate and normalize token (optional but must be string if present)
+        const { token: rawToken } = event.data;
+        const normalizedToken = rawToken !== undefined && rawToken !== null && typeof rawToken === 'string' 
+          ? rawToken 
+          : '';
+
+        // ── Proxy mode ───────────────────────────────────────────────────────
+        // Parent sends proxy: true when the host application will open the real
+        // WebSocket to the AD4M daemon and proxy frames via postMessage.
+        // The URL/port fields are not needed in this path.
+        if (event.data.proxy) {
+          try {
+            this.token = normalizedToken;
+            if (normalizedToken) {
+              setLocal('ad4m-token', normalizedToken);
+            } else {
+              removeLocal('ad4m-token');
+            }
+
+            this.notifyConnectionChange('connecting');
+            this.ad4mClient = new Ad4mClient(
+              'http://proxy', // URL ignored by PostMessageWebSocket
+              normalizedToken,
+              false,          // defer subscriptions until auth confirmed
+              { webSocketImpl: PostMessageWebSocket as unknown as new (url: string) => WebSocket }
+            );
+            this.notifyConnectionChange('connected');
+            await this.checkAuth();
+          } catch (error) {
+            console.error('[Ad4m Connect] Failed to initialize proxy client from AD4M_CONFIG:', error);
+            this.rejectEmbedded(error as Error);
+          }
+          return;
+        }
+
+        // ── Direct mode (desktop / local where PNA is not an issue) ──────────
         // Validate and normalize port
-        const { port: rawPort, token: rawToken } = event.data;
-        
+        const { port: rawPort } = event.data;
+
         if (rawPort === undefined || rawPort === null) {
           const error = new Error('AD4M_CONFIG missing required field: port');
           console.error('[Ad4m Connect]', error.message);
@@ -374,11 +411,6 @@ export default class Ad4mConnect extends EventTarget {
           this.rejectEmbedded(error);
           return;
         }
-        
-        // Validate and normalize token (optional but must be string if present)
-        const normalizedToken = rawToken !== undefined && rawToken !== null && typeof rawToken === 'string' 
-          ? rawToken 
-          : '';
         
         try {
           // Set connection details from parent (after successful validation)

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -468,17 +468,14 @@ export default class Ad4mConnect extends EventTarget {
     
     // Request AD4M config from parent window
     console.log('[Ad4m Connect] Requesting AD4M config from parent window');
-    // Determine the actual parent origin for postMessage targeting.
-    // Prefer document.referrer (the real parent), validated against allowedOrigins.
-    // Fall back to '*' only when no origin information is available.
-    let parentOrigin = '*';
-    const referrerOrigin = document.referrer ? new URL(document.referrer).origin : null;
-    if (referrerOrigin && this.options.allowedOrigins?.includes(referrerOrigin)) {
-      parentOrigin = referrerOrigin;
-    } else if (this.options.allowedOrigins && this.options.allowedOrigins.length === 1) {
-      parentOrigin = this.options.allowedOrigins[0];
-    }
-    window.parent.postMessage({ type: 'REQUEST_AD4M_CONFIG' }, parentOrigin);
+    // REQUEST_AD4M_CONFIG carries no sensitive data — it is a pure handshake
+    // signal asking the parent to respond with credentials. We use '*' because
+    // at this point we don't yet know which of the allowedOrigins the parent is
+    // actually at (e.g. WE dev:web and dev:electron run on different ports, both
+    // listed in allowedOrigins). Security is enforced on the *incoming* side:
+    // the AD4M_CONFIG listener below validates event.origin against
+    // allowedOrigins before accepting any credentials.
+    window.parent.postMessage({ type: 'REQUEST_AD4M_CONFIG' }, '*');
   }
 
   // Local authentication

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -399,14 +399,18 @@ export default class Ad4mConnect extends EventTarget {
               throw new Error('AD4M proxy mode requires a non-opaque parent origin. Ensure the host iframe is not sandboxed without allow-same-origin.');
             }
             const parentOrigin = event.origin;
-            const wsImpl = (url: string) => new PostMessageWebSocket(url, parentOrigin);
+            // Must be a real constructor class — graphql-ws calls `new webSocketImpl(url)`.
+            // Arrow functions cannot be called with `new`, so we use a class expression here.
+            class WsImpl extends PostMessageWebSocket {
+              constructor(url: string) { super(url, parentOrigin); }
+            }
 
             this.notifyConnectionChange('connecting');
             this.ad4mClient = new Ad4mClient(
               'http://proxy', // URL ignored by PostMessageWebSocket
               normalizedToken,
               false,          // defer subscriptions until auth confirmed
-              { webSocketImpl: wsImpl as unknown as new (url: string) => WebSocket }
+              { webSocketImpl: WsImpl as unknown as new (url: string) => WebSocket }
             );
             this.notifyConnectionChange('connected');
             await this.checkAuth();

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -1,5 +1,6 @@
 import { isEmbedded, setLocal, getLocal, removeLocal, checkConnection, wsUrlToHttpBase } from './utils';
 import { PostMessageWebSocket } from './PostMessageWebSocket';
+import { makePostMessageFetch } from './PostMessageFetch';
 import { Ad4mClient, VerificationRequestResult } from "@coasys/ad4m";
 import autoBind from "auto-bind";
 
@@ -405,12 +406,14 @@ export default class Ad4mConnect extends EventTarget {
               constructor(url: string) { super(url, parentOrigin); }
             }
 
+            const fetchImpl = makePostMessageFetch(parentOrigin);
+
             this.notifyConnectionChange('connecting');
             this.ad4mClient = new Ad4mClient(
-              'http://proxy', // URL ignored by PostMessageWebSocket
+              'http://proxy', // URL ignored by PostMessageWebSocket; HTTP requests are proxied via fetchImpl
               normalizedToken,
               false,          // defer subscriptions until auth confirmed
-              { webSocketImpl: WsImpl as unknown as new (url: string) => WebSocket }
+              { webSocketImpl: WsImpl as unknown as new (url: string) => WebSocket, fetchImpl }
             );
             this.notifyConnectionChange('connected');
             await this.checkAuth();

--- a/core/src/Ad4mClient.ts
+++ b/core/src/Ad4mClient.ts
@@ -29,10 +29,15 @@ export class Ad4mClient {
     #runtimeClient: RuntimeClient
     #aiClient: AIClient
 
-    constructor(baseUrl: string, token?: string, subscribe: boolean = true) {
+    constructor(
+        baseUrl: string,
+        token?: string,
+        subscribe: boolean = true,
+        options?: { webSocketImpl?: new (url: string) => WebSocket }
+    ) {
         this.#baseUrl = baseUrl
         this.#token = token
-        this.#apiClient = new ApiClient(baseUrl, token)
+        this.#apiClient = new ApiClient(baseUrl, token, options?.webSocketImpl)
         this.#agentClient = new AgentClient(baseUrl, token, subscribe, this.#apiClient)
         this.#expressionClient = new ExpressionClient(baseUrl, token, this.#apiClient)
         this.#languageClient = new LanguageClient(baseUrl, token, this.#apiClient)

--- a/core/src/Ad4mClient.ts
+++ b/core/src/Ad4mClient.ts
@@ -33,11 +33,11 @@ export class Ad4mClient {
         baseUrl: string,
         token?: string,
         subscribe: boolean = true,
-        options?: { webSocketImpl?: new (url: string) => WebSocket }
+        options?: { webSocketImpl?: new (url: string) => WebSocket; fetchImpl?: typeof fetch }
     ) {
         this.#baseUrl = baseUrl
         this.#token = token
-        this.#apiClient = new ApiClient(baseUrl, token, options?.webSocketImpl)
+        this.#apiClient = new ApiClient(baseUrl, token, options?.webSocketImpl, options?.fetchImpl)
         this.#agentClient = new AgentClient(baseUrl, token, subscribe, this.#apiClient)
         this.#expressionClient = new ExpressionClient(baseUrl, token, this.#apiClient)
         this.#languageClient = new LanguageClient(baseUrl, token, this.#apiClient)

--- a/core/src/ai/AIClient.ts
+++ b/core/src/ai/AIClient.ts
@@ -156,7 +156,7 @@ export class AIClient {
             typedAudio.byteOffset + typedAudio.byteLength
         );
 
-        const response = await fetch(`${baseUrl}/api/v1/ai/transcription/feed`, {
+        const response = await this.#apiClient.doFetch(`${baseUrl}/api/v1/ai/transcription/feed`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/octet-stream',

--- a/core/src/apiClient.ts
+++ b/core/src/apiClient.ts
@@ -43,10 +43,12 @@ interface PendingCall {
 export class ApiClient {
     private baseUrl: string
     private token?: string
+    private readonly _webSocketImpl?: new (url: string) => WebSocket
 
-    constructor(baseUrl: string, token?: string) {
+    constructor(baseUrl: string, token?: string, webSocketImpl?: new (url: string) => WebSocket) {
         this.baseUrl = baseUrl
         this.token = token
+        this._webSocketImpl = webSocketImpl
     }
 
     getBaseUrl(): string { return this.baseUrl }
@@ -78,7 +80,7 @@ export class ApiClient {
     }
 
     private _ensureWs(): void {
-        if (this._ws && (this._ws.readyState === WebSocket.OPEN || this._ws.readyState === WebSocket.CONNECTING)) {
+        if (this._ws && (this._ws.readyState === 1 /* OPEN */ || this._ws.readyState === 0 /* CONNECTING */)) {
             return
         }
         // Prevent duplicate connections from concurrent callers
@@ -91,7 +93,8 @@ export class ApiClient {
         })
 
         const url = this._getWsUrl()
-        const ws = new WebSocket(url)
+        const WsImpl = this._webSocketImpl ?? WebSocket
+        const ws = new WsImpl(url)
         this._ws = ws
 
         ws.onopen = () => {
@@ -160,7 +163,7 @@ export class ApiClient {
     private _startPing(): void {
         this._stopPing()
         this._wsPingTimer = setInterval(() => {
-            if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+            if (this._ws && this._ws.readyState === 1 /* OPEN */) {
                 this._ws.send(JSON.stringify({ type: 'ping' }))
             }
         }, 30_000)
@@ -220,7 +223,7 @@ export class ApiClient {
                 timer,
             })
 
-            if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+            if (this._ws && this._ws.readyState === 1 /* OPEN */) {
                 this._ws.send(JSON.stringify(message))
             } else {
                 this._pendingCalls.delete(id)

--- a/core/src/apiClient.ts
+++ b/core/src/apiClient.ts
@@ -44,15 +44,22 @@ export class ApiClient {
     private baseUrl: string
     private token?: string
     private readonly _webSocketImpl?: new (url: string) => WebSocket
+    private readonly _fetchImpl?: typeof fetch
 
-    constructor(baseUrl: string, token?: string, webSocketImpl?: new (url: string) => WebSocket) {
+    constructor(baseUrl: string, token?: string, webSocketImpl?: new (url: string) => WebSocket, fetchImpl?: typeof fetch) {
         this.baseUrl = baseUrl
         this.token = token
         this._webSocketImpl = webSocketImpl
+        this._fetchImpl = fetchImpl
     }
 
     getBaseUrl(): string { return this.baseUrl }
     getToken(): string | undefined { return this.token }
+
+    /** Perform an HTTP request, using an injected fetch implementation if provided. */
+    doFetch(url: string, init: RequestInit): Promise<Response> {
+        return this._fetchImpl ? this._fetchImpl(url, init) : fetch(url, init)
+    }
 
     setToken(token: string) {
         this.token = token


### PR DESCRIPTION
# feat: add postMessage WebSocket & HTTP proxy for embedded app support

## Summary

Adds injectable WebSocket and fetch implementations to `ApiClient` / `Ad4mClient`, and two new proxy classes — `PostMessageWebSocket` and `PostMessageFetch` — that tunnel all AD4M traffic through `window.parent.postMessage`. Together these allow an embedded app to connect to an AD4M node without opening direct WebSocket or HTTP connections. The host application handles both on its behalf, with strict origin pinning enforced throughout.

## Problem

When an AD4M-connected app (e.g. Flux) is loaded inside an iframe hosted by a web-deployed shell (e.g. WE at `https://coasys-we.netlify.app`), Chrome's Private Network Access (PNA) Phase 2 enforcement blocks the iframe from opening `ws://localhost:12000` or `http://localhost:12000` directly.

PNA is enforced **per requesting origin**. The shell app (`coasys-we.netlify.app`) may have been granted permission by the user, but that grant does not extend to embedded app origins (`fluxsocial-dev.netlify.app`). The AD4M launcher already responds with the correct `Access-Control-Allow-Private-Network: true` header — the block is browser-side and per-origin, so server-side headers alone cannot fix it.

## Solution

The shell application (WE) opens the real WebSocket and performs real HTTP fetches from its own origin — where PNA permission has already been granted — and proxies all traffic to/from the embedded app via `postMessage`.

### `core/src/apiClient.ts`

- Constructor accepts optional `webSocketImpl` and `fetchImpl` parameters
- `_ensureWs()` uses `this._webSocketImpl ?? WebSocket` when creating the connection
- New `doFetch()` method uses `this._fetchImpl ?? fetch` for all HTTP requests, making HTTP calls injectable alongside WebSocket
- Replaced `WebSocket.OPEN` / `WebSocket.CONNECTING` static references with numeric literals (`1` / `0`) to avoid a static property dependency on the global `WebSocket` class

### `core/src/Ad4mClient.ts`

- Constructor accepts an optional fourth parameter: `options?: { webSocketImpl?: new (url: string) => WebSocket; fetchImpl?: typeof fetch }`
- Both `webSocketImpl` and `fetchImpl` are threaded through to `ApiClient`

### `core/src/ai/AIClient.ts`

- Audio transcription endpoint now calls `this.#apiClient.doFetch()` instead of bare `fetch()`, so it routes through the injected fetch implementation in proxy mode

### `connect/src/PostMessageWebSocket.ts` *(new file)*

A `WebSocket`-compatible class implementing the `AD4M_PROXY_WS_*` postMessage protocol:

| Direction | Message type | Meaning |
|-----------|-------------|---------|
| embedded → host | `AD4M_PROXY_WS_CONNECT` | Open a real WebSocket connection |
| embedded → host | `AD4M_PROXY_WS_SEND` | Send a frame |
| embedded → host | `AD4M_PROXY_WS_CLOSE` | Close the connection |
| host → embedded | `AD4M_PROXY_WS_OPEN` | Connection established |
| host → embedded | `AD4M_PROXY_WS_MESSAGE` | Incoming frame |
| host → embedded | `AD4M_PROXY_WS_ERROR` | Connection error |
| host → embedded | `AD4M_PROXY_WS_CLOSED` | Connection closed |

Security hardening:
- **Origin pinning**: `targetOrigin` is captured from the verified `AD4M_CONFIG` sender and used for all three `postMessage` calls (`CONNECT`, `SEND`, `CLOSE`) — no wildcard `'*'`
- **Incoming frame validation**: every received message checks `e.origin === this._targetOrigin`, rejecting frames from a parent that navigated to a different origin after connection setup
- **30s connection timeout**: if the host never sends `AD4M_PROXY_WS_OPEN`, `onerror` + `onclose` fire automatically so callers fail fast rather than hanging indefinitely
- **State + listener cleanup**: the message listener is removed on error and close, preventing memory leaks and stale handlers

### `connect/src/PostMessageFetch.ts` *(new file)*

A factory (`makePostMessageFetch(targetOrigin)`) returning a `fetch`-compatible function that proxies HTTP requests through `window.parent` via the `AD4M_PROXY_HTTP_*` protocol:

| Direction | Message type | Meaning |
|-----------|-------------|---------|
| embedded → host | `AD4M_PROXY_HTTP_REQUEST` | Perform a real HTTP fetch |
| host → embedded | `AD4M_PROXY_HTTP_RESPONSE` | Response status, headers, body |
| host → embedded | `AD4M_PROXY_HTTP_ERROR` | Network or timeout error |

Key details:
- Each request carries a unique `id` so concurrent calls are matched correctly
- Request body is extracted as an `ArrayBuffer` and transferred zero-copy via the structured-clone transfer list
- Headers are serialised to a plain `Record<string, string>` before posting
- **60s timeout** per request with cleanup of the listener on completion or error
- **Origin pinning**: all `postMessage` calls use the injected `targetOrigin`; the response handler validates `event.origin` before resolving

### `connect/src/core.ts`

- **Proxy mode** (triggered by `event.data.proxy === true` in `AD4M_CONFIG`):
  - `allowedOrigins` is now **mandatory** in proxy mode — if absent or empty, `AD4M_CONFIG` is rejected with an error rather than silently accepted from any embedding site
  - `event.origin` is validated against `allowedOrigins` before proceeding
  - Opaque origins (sandboxed iframes without `allow-same-origin`) are explicitly rejected
  - `event.origin` is captured as `parentOrigin` and passed to both `PostMessageWebSocket` and `makePostMessageFetch` — no wildcard at any point
  - `WsImpl` is defined as a `class extends PostMessageWebSocket` (not an arrow function) so `graphql-ws` can call `new WsImpl(url)` correctly
  - `Ad4mClient` is constructed with both `webSocketImpl: WsImpl` and `fetchImpl`
  - Token is normalised before the proxy/direct fork so both paths share the same validation logic
- **Direct mode**: unchanged — existing `buildClient()` flow for desktop/Electron
- **`REQUEST_AD4M_CONFIG`**: uses `'*'` target with an explicit comment explaining why — this message carries no sensitive data, and at send time the parent's origin is not yet known; security is enforced on the incoming `AD4M_CONFIG` reply

## Notes

- No changes required in consuming applications (e.g. Flux) — both proxies are transparent to app-level code
- The host application must implement both the `AD4M_PROXY_WS_*` and `AD4M_PROXY_HTTP_*` protocols, configure `allowedOrigins`, and send `{ proxy: true }` in `AD4M_CONFIG` instead of `{ port }`
- Desktop/Electron deployments are unaffected — they continue to use the direct WebSocket and fetch paths