### PR TITLE
feat: support localhost:* wildcard in allowedOrigins for dev environments

### DIFF
--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -12,6 +12,27 @@ const DEFAULT_INDEX_URL = "https://hosting.ad4m.dev";
 const CREDIT_POLL_INTERVAL_MS = 60000;
 const DEFAULT_LOW_CREDIT_THRESHOLD = 10;
 
+/**
+ * Check whether `origin` is permitted by an entry in `allowedOrigins`.
+ * Supports the wildcard pattern `http://localhost:*` / `https://localhost:*`
+ * to allow any localhost port (useful in development environments where tools
+ * run on arbitrary ports). All other patterns require an exact match.
+ */
+function originAllowed(allowedOrigins: string[], origin: string): boolean {
+  return allowedOrigins.some((pattern) => {
+    if (pattern === 'http://localhost:*' || pattern === 'https://localhost:*') {
+      try {
+        const u = new URL(origin);
+        const scheme = pattern.startsWith('https') ? 'https:' : 'http:';
+        return u.hostname === 'localhost' && u.protocol === scheme;
+      } catch {
+        return false;
+      }
+    }
+    return pattern === origin;
+  });
+}
+
 export default class Ad4mConnect extends EventTarget {
   options: Ad4mConnectOptions;
   embedded: boolean;
@@ -357,13 +378,13 @@ export default class Ad4mConnect extends EventTarget {
             this.rejectEmbedded(new Error('proxy mode requires allowedOrigins'));
             return;
           }
-          if (!event.origin || !this.options.allowedOrigins.includes(event.origin)) {
+          if (!event.origin || !originAllowed(this.options.allowedOrigins, event.origin)) {
             console.warn('[Ad4m Connect] Rejected AD4M_CONFIG from unauthorized origin:', event.origin);
             this.rejectEmbedded(new Error(`Unauthorized origin: ${event.origin}`));
             return;
           }
         } else if (this.options.allowedOrigins && this.options.allowedOrigins.length > 0) {
-          if (!event.origin || !this.options.allowedOrigins.includes(event.origin)) {
+          if (!event.origin || !originAllowed(this.options.allowedOrigins, event.origin)) {
             console.warn('[Ad4m Connect] Rejected AD4M_CONFIG from unauthorized origin:', event.origin);
             this.rejectEmbedded(new Error(`Unauthorized origin: ${event.origin}`));
             return;


### PR DESCRIPTION
# feat: support `localhost:*` wildcard in `allowedOrigins`

## Summary

Adds wildcard pattern support to the `allowedOrigins` origin validation in `Ad4mConnect`, allowing `http://localhost:*` (or `https://localhost:*`) to match any localhost port.

## Motivation

Previously, `allowedOrigins` required exact origin strings, so each dev tool port (wind tunnel, automation scripts, future agents, etc.) had to be listed explicitly. This was brittle and would break whenever a new tool ran on an unlisted port.

In production the `allowedOrigins` list remains strict exact-match (e.g. `https://coasys-we.netlify.app`), so there is no security regression. The wildcard is only meaningful in dev builds where the env var is set to `http://localhost:*`.

## Changes

### `connect/src/core.ts`

Added a module-level `originAllowed()` helper that replaces the two `allowedOrigins.includes()` calls in `initializeEmbeddedMode()`:

- Exact strings continue to require an exact match (production behaviour unchanged).
- `http://localhost:*` or `https://localhost:*` matches any `localhost` origin on the corresponding scheme, regardless of port.
- Invalid/unparseable origins always fail.

## Usage

In a consuming app's `.env.development`:

```dotenv
VITE_ALLOWED_ORIGINS=http://localhost:*
```

In `.env.production`, keep using exact origins:

```dotenv
VITE_ALLOWED_ORIGINS=https://coasys-we.netlify.app
```

## Published

`@coasys/ad4m-connect@0.13.0-localhost-wildcard-1` — npm tag: `dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced origin validation for embedded mode initialization with improved pattern matching for localhost origins, strengthening security controls over accepted parent window sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->