### PR TITLE
fix(model-query): lazy-load resolveLanguage languages before expression fetch

### DIFF
--- a/rust-executor/src/perspectives/model_query/query.rs
+++ b/rust-executor/src/perspectives/model_query/query.rs
@@ -349,6 +349,24 @@ async fn resolve_language_transforms(
                 Value::String(uri) if !uri.starts_with("literal:") => {
                     match crate::languages::LanguageController::parse_expr_url(uri) {
                         Ok((lang, expr_addr)) => {
+                            // Ensure the language is loaded before attempting to fetch the
+                            // expression. The runtimes map only contains languages that have
+                            // been explicitly installed/loaded; languages referenced via
+                            // resolveLanguage (e.g. FILE_STORAGE_LANGUAGE) may not be
+                            // loaded yet at query time.
+                            if !controller.is_language_loaded(&lang).await {
+                                if let Err(e) = controller.language_by_ref(&lang).await {
+                                    log::warn!(
+                                        "resolve_language_transforms: failed to load language {} \
+                                         for property '{}': {}",
+                                        lang,
+                                        prop.name,
+                                        e
+                                    );
+                                    instance[&prop.name] = current;
+                                    continue;
+                                }
+                            }
                             match controller.get_expression(&lang, &expr_addr).await {
                                 Ok(Some(expr_json)) => {
                                     let data =


### PR DESCRIPTION
# fix(model-query): lazy-load resolveLanguage languages before expression fetch

## Problem

Model properties decorated with `resolveLanguage` (e.g. `FILE_STORAGE_LANGUAGE`) were silently returning raw expression URLs instead of decoded file data when read via `modelQuery`.

The root cause is in `resolve_language_transforms()` in `rust-executor/src/perspectives/model_query/query.rs`. When the function attempts to fetch an expression it calls `controller.get_expression()`, which internally calls `execute_on_language()`. If the language isn't already loaded in the executor's runtime map, `execute_on_language` returns `Err(LanguageError::NotFound)`. This error was caught by the `_ =>` fallback arm, which silently substituted the raw expression URL as the resolved value.

Downstream transforms like `fileToDataUri` then receive a plain URL string. The transform's `exists(path('file_storage://data_base64'))` check fails on a string (no `data_base64` field), so the `else` branch fires `focus()` and the raw URL passes through unchanged — ending up as the `src` on image elements and causing `ERR_UNKNOWN_URL_SCHEME` in the renderer.

The language isn't auto-loaded because `FILE_STORAGE_LANGUAGE` (and other app-level languages) are only loaded on demand, not preloaded at startup.

## Fix

Before calling `get_expression`, check whether the language is already loaded with `is_language_loaded()`. If not, call `language_by_ref()` to lazy-load it first. If the load fails, log a warning and skip the transform for that property (falling back to the raw value, as before). This mirrors the identical guard already used in `mcp/tools/profiles.rs` for expression creation.

```rust
if !controller.is_language_loaded(&lang).await {
    if let Err(e) = controller.language_by_ref(&lang).await {
        log::warn!("resolve_language_transforms: failed to load language {} ...", ...);
        instance[&prop.name] = current;
        continue;
    }
}
// then get_expression as before
```

## Impact

- **Flux**: community images (`image`, `thumbnail` on the `Community` model) now resolve correctly
- **WE**: `avatar` and `coverImage` on `AgentProfile`, and `avatar`/`coverImage` on `Space`, now resolve correctly
- Any other model property using `resolveLanguage` + a transform benefits from the same fix

## Files Changed

- `rust-executor/src/perspectives/model_query/query.rs` — `resolve_language_transforms()` function

## Notes

- This PR targets `dev` and is independent of `feat/localhost-wildcard-origin`
- No changes to the public API or SHACL schema format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language reference handling to ensure proper loading before processing queries. Missing languages now log warnings while preserving original data, preventing silent failures and enhancing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->