### PR TITLE
perf(executor): fused projection counts + CONSTRUCT subgraph hydration for findAll

### DIFF
--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -847,6 +847,7 @@ export class Ad4mModel {
     if (query.limit !== undefined) queryInput.limit = query.limit;
     if (query.count !== undefined) queryInput.count = query.count;
     if (query.withMetadata !== undefined) queryInput.withMetadata = query.withMetadata;
+    if (query.useConstruct !== undefined) queryInput.useConstruct = query.useConstruct;
     queryInput.deepQuery = query.deepQuery ?? true;
 
     // Conformance getters, where filters, and target shapes for includes

--- a/core/src/model/types.ts
+++ b/core/src/model/types.ts
@@ -154,6 +154,31 @@ export type Query = {
    * link-level metadata in the UI.
    */
   withMetadata?: boolean;
+  /**
+   * When `true`, ask the executor to materialise the entire query
+   * subgraph (instance triples + included relation targets + their
+   * properties, recursively) via a single SPARQL `CONSTRUCT` and
+   * reconstruct the JSON tree from the resulting graph in Rust.
+   * Collapses every forward include — at any depth — into one round
+   * trip instead of one-recursive-pipeline-per-include-per-depth.
+   *
+   * Falls back silently to the legacy recursive pipeline when the
+   * query can't be expressed as a single CONSTRUCT.  Disqualifiers
+   * (handled by the executor):
+   *   - non-empty `projections`,
+   *   - non-zero `offset`,
+   *   - per-include `where` / `order` / `limit` / `offset` / `count`,
+   *   - reverse-direction includes (`@BelongsTo`),
+   *   - property/relation getters,
+   *   - `withMetadata: true` (reifier-metadata fold not yet folded
+   *     into the CONSTRUCT body),
+   *   - `count: true` (CONSTRUCT can't aggregate).
+   *
+   * Default `undefined` / `false` engages the back-compat pipeline.
+   * Set `true` on call sites that materialise an include tree but
+   * don't need per-include constraints or link-level metadata.
+   */
+  useConstruct?: boolean;
 };
 
 /**
@@ -353,6 +378,7 @@ type StrictTypedQuery<T extends Ad4mModel> = {
   count?: boolean;
   deepQuery?: boolean;
   withMetadata?: boolean;
+  useConstruct?: boolean;
 };
 
 export type TypedQuery<T extends Ad4mModel> =

--- a/rust-executor/src/perspectives/model_query/construct_builder.rs
+++ b/rust-executor/src/perspectives/model_query/construct_builder.rs
@@ -76,10 +76,7 @@ const MAX_CONSTRUCT_DEPTH: u8 = 16;
 ///    CONSTRUCT body doesn't support.  Falls back so the caller still gets
 ///    `total_count`.
 /// 9. **Nested include depth > MAX_CONSTRUCT_DEPTH**: defensive cap.
-pub(super) fn can_use_construct(
-    query: &ModelQueryInput,
-    shape: &ModelShape,
-) -> bool {
+pub(super) fn can_use_construct(query: &ModelQueryInput, shape: &ModelShape) -> bool {
     // (1)
     if query.use_construct != Some(true) {
         return false;
@@ -261,10 +258,7 @@ pub(super) fn build_construct_sparql(
 /// scopes the CONSTRUCT to the matching instances.  Uses the same
 /// conformance + where logic as the legacy `build_instance_sparql` so
 /// pagination / WHERE-pushdown stays consistent across the two paths.
-fn build_source_selector(
-    shape: &ModelShape,
-    query: &ModelQueryInput,
-) -> Result<String, Error> {
+fn build_source_selector(shape: &ModelShape, query: &ModelQueryInput) -> Result<String, Error> {
     let mut patterns: Vec<String> = Vec::new();
 
     // Conformance — at minimum the entry-type flag.  Mirrors the
@@ -275,10 +269,7 @@ fn build_source_selector(
                 if validate_iri(&prop.predicate).is_err() || validate_iri(initial).is_err() {
                     continue;
                 }
-                patterns.push(format!(
-                    "?source <{}> <{}> .",
-                    prop.predicate, initial
-                ));
+                patterns.push(format!("?source <{}> <{}> .", prop.predicate, initial));
             }
         }
     }
@@ -352,10 +343,7 @@ fn build_source_selector(
                     if validate_iri(val).is_ok() {
                         // Treat as IRI — same shape as id-eq but on the
                         // user-specified property predicate.
-                        patterns.push(format!(
-                            "?source <{}> <{val}> .",
-                            prop.predicate
-                        ));
+                        patterns.push(format!("?source <{}> <{val}> .", prop.predicate));
                     }
                 }
             }
@@ -426,7 +414,11 @@ fn emit_include_branches(
     }
 
     for (rel_name, val) in include {
-        let rel = match parent_shape.include_relations.iter().find(|r| r.name == *rel_name) {
+        let rel = match parent_shape
+            .include_relations
+            .iter()
+            .find(|r| r.name == *rel_name)
+        {
             Some(r) => r,
             None => continue,
         };
@@ -465,8 +457,7 @@ fn emit_include_branches(
 
         // Branch B: target's own property triples.
         {
-            let predicate_filter =
-                build_predicate_values(&target_shape.properties, "?_predicate");
+            let predicate_filter = build_predicate_values(&target_shape.properties, "?_predicate");
             let mut lines: Vec<String> = Vec::new();
             lines.push(format!("        {{ {inner_select} }}"));
             lines.push(format!(
@@ -514,10 +505,7 @@ fn build_target_conformance(shape: &ModelShape, target_var: &str) -> Vec<String>
         if prop.is_required && prop.is_flag {
             if let Some(initial) = &prop.initial_value {
                 if validate_iri(&prop.predicate).is_ok() && validate_iri(initial).is_ok() {
-                    out.push(format!(
-                        "{target_var} <{}> <{}> .",
-                        prop.predicate, initial
-                    ));
+                    out.push(format!("{target_var} <{}> <{}> .", prop.predicate, initial));
                 }
             }
         }
@@ -651,8 +639,8 @@ fn hydrate_one(
             None => continue,
         };
 
-        if prop.is_collection || (matches!(prop.direction.as_deref(), Some("forward"))
-            && !prop.is_scalar_relation)
+        if prop.is_collection
+            || (matches!(prop.direction.as_deref(), Some("forward")) && !prop.is_scalar_relation)
         {
             obj.insert(
                 prop.name.clone(),

--- a/rust-executor/src/perspectives/model_query/construct_builder.rs
+++ b/rust-executor/src/perspectives/model_query/construct_builder.rs
@@ -1,0 +1,700 @@
+//! Single-round-trip subgraph hydration via SPARQL `CONSTRUCT`.
+//!
+//! This is audit item **I** from `flux/docs/sparql-to-ad4m-model-migration.md`:
+//! the "perfectly elegant `Ad4mModel` → SPARQL pipeline" endpoint.  Instead of
+//! the historical recursive `execute_model_query_inner` pipeline that fires one
+//! main SELECT + one COUNT + one nested SELECT *per* `include` relation *per*
+//! level of nesting, the CONSTRUCT path materialises every triple needed for
+//! the entire query subgraph — instance properties, included relation targets,
+//! the included targets' properties, and so on recursively — in **one** round
+//! trip.  A graph walker in [`walk_graph_to_instances`] then reassembles the
+//! JSON tree from the returned triples.
+//!
+//! # When the CONSTRUCT path engages
+//!
+//! Only when [`can_use_construct`] returns `true`.  The fallback is silent —
+//! callers always see the same JSON output regardless of which path runs.
+//! Features that disqualify a query from the CONSTRUCT path are kept in
+//! [`can_use_construct`] as guard clauses with a one-line explanation each.
+//!
+//! # Round-trip count
+//!
+//! - Historical pipeline at include depth N: `1 main + 1 count + N includes
+//!   each firing their own 1+1 = 2 round trips → 1 + 1 + 2N`.
+//! - CONSTRUCT pipeline: **1 round trip** regardless of include depth.
+//!
+//! The walker is `O(triples)` and uses two HashMap lookups per triple, so the
+//! Rust-side cost stays linear in the result-set size.
+
+use std::collections::{HashMap, HashSet};
+
+use deno_core::anyhow::{anyhow, Error};
+use serde_json::Value;
+
+use super::types::{
+    IncludeValue, ModelQueryInput, ModelShape, ShapeProperty, ShapeResolver, WhereCondition,
+};
+use super::utils::validate_iri;
+
+/// Maximum CONSTRUCT include recursion depth.  Mirrors
+/// [`utils::MAX_INCLUDE_DEPTH`](super::utils::MAX_INCLUDE_DEPTH) but applied
+/// here at *plan* time so a malformed include map can't drive the SPARQL
+/// builder into runaway pattern emission.
+const MAX_CONSTRUCT_DEPTH: u8 = 16;
+
+/// Returns `true` when the query can be satisfied by a single CONSTRUCT
+/// round trip, and `false` when the recursive SELECT pipeline has to run.
+///
+/// Disqualifiers (each one cheap to check; bail early):
+///
+/// 1. `use_construct != Some(true)` — caller hasn't opted in.
+/// 2. **Projections**: lightweight count/list projections (`$likeCount`,
+///    `$comments`, …) require post-hydration `GROUP BY` + cross-relation
+///    joins that don't fit cleanly into a single CONSTRUCT body.  Handled
+///    by the existing `projection.rs` pipeline.
+/// 3. **Pagination via OFFSET**: a non-zero `offset` requires the inner
+///    pagination subquery to apply ORDER BY before OFFSET, which conflicts
+///    with the CONSTRUCT WHERE's "materialise the whole subgraph" shape.
+///    `limit` alone is fine — we wrap the source-selector in an inner
+///    SELECT.  Zero-offset is allowed.
+/// 4. **Includes with per-relation `where` / `order` / `limit` / `offset`**:
+///    same reason.  CONSTRUCT can't apply per-include constraints — the
+///    WHERE block is one global pattern.
+/// 5. **Reverse-direction includes** (`@BelongsTo`): the source-arrow flip
+///    requires a separate scan pattern.  Handled by the existing
+///    `resolve_reverse_relations` path; could be folded in via a UNION
+///    in a future PR.
+/// 6. **Property getters or relation-on-getter**: `ASK { … }` / `SELECT { … }`
+///    getter bodies are arbitrary SPARQL fragments that may overlap with
+///    the CONSTRUCT body.  Skip rather than risk semantic drift.
+/// 7. **Reifier metadata requested** (`with_metadata != Some(false)`): the
+///    full pipeline needs the per-row author/timestamp fold that the
+///    CONSTRUCT body would have to emit per included entity.  A future
+///    extension could fold the reifier-metadata join into the CONSTRUCT
+///    body keyed by the relation predicate.
+/// 8. **Aggregation / count requested**: COUNT requires `GROUP BY` which a
+///    CONSTRUCT body doesn't support.  Falls back so the caller still gets
+///    `total_count`.
+/// 9. **Nested include depth > MAX_CONSTRUCT_DEPTH**: defensive cap.
+pub(super) fn can_use_construct(
+    query: &ModelQueryInput,
+    shape: &ModelShape,
+) -> bool {
+    // (1)
+    if query.use_construct != Some(true) {
+        return false;
+    }
+    // (2)
+    if query.projections.as_ref().map_or(false, |p| !p.is_empty()) {
+        return false;
+    }
+    // (3) pagination — offset must be 0 (or unset)
+    if query.offset.unwrap_or(0) > 0 {
+        return false;
+    }
+    // (7) reifier metadata
+    if query.with_metadata.unwrap_or(true) {
+        return false;
+    }
+    // (8) count fast-path
+    if query.count == Some(true) {
+        return false;
+    }
+    // (4) + (5) include sub-queries with constraints / reverse direction
+    if let Some(include) = &query.include {
+        if !includes_are_construct_compatible(include, shape) {
+            return false;
+        }
+    }
+    // (6) property/relation getters on the top-level shape
+    for prop in &shape.properties {
+        if prop.getter.is_some() {
+            return false;
+        }
+    }
+    true
+}
+
+/// Recursive walk that checks every level of the include tree for the
+/// disqualifying constraints from [`can_use_construct`] points 4 and 5
+/// (per-include `where`/`order`/`limit`/`offset`/`count`, reverse direction).
+///
+/// Returns `false` as soon as it finds any disqualifier — the caller falls
+/// back to the legacy recursive pipeline.
+fn includes_are_construct_compatible(
+    include: &HashMap<String, IncludeValue>,
+    parent_shape: &ModelShape,
+) -> bool {
+    for (rel_name, val) in include {
+        // Per-include constraints — disqualify regardless of relation.
+        if let IncludeValue::SubQuery(sq) = val {
+            if sq.where_clause.is_some()
+                || sq.order.is_some()
+                || sq.limit.is_some()
+                || sq.offset.is_some()
+                || sq.count == Some(true)
+            {
+                return false;
+            }
+        }
+        // Relation direction + recursion.  When the relation isn't
+        // declared on this shape, leave the legacy path to handle it
+        // (it logs + skips silently).
+        if let Some(rel) = parent_shape
+            .include_relations
+            .iter()
+            .find(|r| r.name == *rel_name)
+        {
+            if rel.direction == "reverse" {
+                return false;
+            }
+            // Recurse into nested sub-includes.  Without a shape resolver
+            // here we can't know the target shape's include_relations, so
+            // we only walk the include map's structure — same-level
+            // constraints + reverse-direction flags at this level get
+            // checked above; nested levels are walked here with the
+            // parent_shape as a fallback (any unknown relation falls
+            // through, same as the top level).
+            if let IncludeValue::SubQuery(sq) = val {
+                if let Some(nested) = &sq.include {
+                    if !includes_are_construct_compatible(nested, parent_shape) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Build a `CONSTRUCT { … } WHERE { … }` query that materialises the entire
+/// requested subgraph.
+///
+/// Shape of the emitted SPARQL (with one `include: { tag: true }` example):
+///
+/// ```sparql
+/// CONSTRUCT {
+///     ?source ?p ?o .
+///     ?source <flux://has_tag> ?_inc_0_t .
+///     ?_inc_0_t ?_inc_0_p ?_inc_0_o .
+/// }
+/// WHERE {
+///     # main pagination + conformance + where
+///     {
+///         SELECT DISTINCT ?source WHERE {
+///             ?source <flux://entry_type> <flux://has_semantic_relationship> .
+///         } LIMIT 10
+///     }
+///     ?source ?p ?o .
+///     VALUES ?p { <flux://entry_type> <flux://has_tag> <flux://has_expression> … }
+///     OPTIONAL {
+///         ?source <flux://has_tag> ?_inc_0_t .
+///         ?_inc_0_t <flux://entry_type> <flux://has_embedding> .
+///         ?_inc_0_t ?_inc_0_p ?_inc_0_o .
+///         VALUES ?_inc_0_p { <flux://entry_type> <flux://embedding> }
+///     }
+/// }
+/// ```
+///
+/// The inner `SELECT ?source` applies the top-level WHERE + LIMIT, so the
+/// CONSTRUCT body only materialises triples for sources that survive the
+/// outer filter.  Each include adds one OPTIONAL block.  Recursive includes
+/// chain — `?_inc_0_t` becomes the parent for `?_inc_0_0_t`, etc.
+///
+/// Returns `Err` when an IRI fails validation; returns `Ok(None)` when the
+/// shape has no predicates at all (degenerate case — caller should fall
+/// back to the legacy pipeline).
+pub(super) fn build_construct_sparql(
+    shape: &ModelShape,
+    query: &ModelQueryInput,
+    resolver: &dyn ShapeResolver,
+) -> Result<Option<String>, Error> {
+    let mut construct_lines: Vec<String> = Vec::new();
+    let mut where_lines: Vec<String> = Vec::new();
+
+    // Inner pagination/scope: SELECT DISTINCT ?source { conformance + where }
+    // LIMIT N.  This is what restricts the CONSTRUCT to the relevant page.
+    let inner_select = build_source_selector(shape, query)?;
+    where_lines.push(format!("    {{ {inner_select} }}"));
+
+    // Main instance triples
+    construct_lines.push("    ?source ?_p ?_o .".to_string());
+    let predicate_filter = build_predicate_values(&shape.properties, "?_p");
+    where_lines.push("    ?source ?_p ?_o .".to_string());
+    if let Some(filter) = predicate_filter {
+        where_lines.push(format!("    {filter}"));
+    }
+
+    // Recursively emit includes
+    if let Some(include) = &query.include {
+        let mut counter: usize = 0;
+        emit_includes(
+            shape,
+            include,
+            "?source",
+            "_inc",
+            &mut counter,
+            0,
+            resolver,
+            &mut construct_lines,
+            &mut where_lines,
+        )?;
+    }
+
+    let construct_body = construct_lines.join("\n");
+    let where_body = where_lines.join("\n");
+
+    Ok(Some(format!(
+        "CONSTRUCT {{\n{construct_body}\n}}\nWHERE {{\n{where_body}\n}}"
+    )))
+}
+
+/// Build the inner `SELECT DISTINCT ?source { ... } LIMIT N` block that
+/// scopes the CONSTRUCT to the matching instances.  Uses the same
+/// conformance + where logic as the legacy `build_instance_sparql` so
+/// pagination / WHERE-pushdown stays consistent across the two paths.
+fn build_source_selector(
+    shape: &ModelShape,
+    query: &ModelQueryInput,
+) -> Result<String, Error> {
+    let mut patterns: Vec<String> = Vec::new();
+
+    // Conformance — at minimum the entry-type flag.  Mirrors the
+    // sparql_builder logic but stripped of the property-fetch shape.
+    for prop in &shape.properties {
+        if prop.is_required && prop.is_flag {
+            if let Some(initial) = &prop.initial_value {
+                if validate_iri(&prop.predicate).is_err() || validate_iri(initial).is_err() {
+                    continue;
+                }
+                patterns.push(format!(
+                    "?source <{}> <{}> .",
+                    prop.predicate, initial
+                ));
+            }
+        }
+    }
+
+    // Conformance fallback: if no flag found, at least require that ?source
+    // has *some* triple matching one of the shape predicates.  Prevents the
+    // CONSTRUCT from matching unrelated subjects.
+    if patterns.is_empty() {
+        let mut any_pred: Option<&str> = None;
+        for prop in &shape.properties {
+            if !prop.predicate.is_empty() && validate_iri(&prop.predicate).is_ok() {
+                any_pred = Some(prop.predicate.as_str());
+                break;
+            }
+        }
+        if let Some(pred) = any_pred {
+            patterns.push(format!("?source <{pred}> ?_any ."));
+        } else {
+            return Err(anyhow!(
+                "build_construct_sparql: shape has no predicates — cannot build a CONSTRUCT scope"
+            ));
+        }
+    }
+
+    // WHERE-clause pushdown: only `id` / `base` equality flavours are
+    // supported here.  Anything else => `can_use_construct` should have
+    // returned false; we'd have fallen back already.  This is the same
+    // subset the legacy `all_where_pushable` handles for the unique-id case.
+    if let Some(wc) = &query.where_clause {
+        if let Some(WhereCondition::String(iri)) = wc.get("id") {
+            if validate_iri(iri).is_ok() {
+                patterns.push(format!("VALUES ?source {{ <{iri}> }}"));
+            }
+        }
+        if let Some(WhereCondition::StringArray(arr)) = wc.get("id") {
+            let safe: Vec<String> = arr
+                .iter()
+                .filter(|s| validate_iri(s).is_ok())
+                .map(|s| format!("<{s}>"))
+                .collect();
+            if !safe.is_empty() {
+                patterns.push(format!("VALUES ?source {{ {} }}", safe.join(" ")));
+            }
+        }
+    }
+
+    let where_body = patterns.join(" ");
+    let mut sql = format!("SELECT DISTINCT ?source WHERE {{ {where_body} }}");
+    if let Some(limit) = query.limit {
+        if limit > 0 {
+            sql.push_str(&format!(" LIMIT {limit}"));
+        }
+    }
+    Ok(sql)
+}
+
+/// Emit `VALUES ?var { <pred1> <pred2> … }` filter over a shape's
+/// predicates.  Returns `None` when the shape has no relevant predicates.
+fn build_predicate_values(props: &[ShapeProperty], var: &str) -> Option<String> {
+    let preds: HashSet<&str> = props
+        .iter()
+        .filter(|p| !p.predicate.is_empty() && validate_iri(&p.predicate).is_ok())
+        .map(|p| p.predicate.as_str())
+        .collect();
+    if preds.is_empty() {
+        None
+    } else {
+        let mut iris: Vec<&&str> = preds.iter().collect();
+        iris.sort();
+        let body: Vec<String> = iris.iter().map(|p| format!("<{p}>")).collect();
+        Some(format!("VALUES {var} {{ {} }}", body.join(" ")))
+    }
+}
+
+/// Recursively emit the CONSTRUCT body + WHERE OPTIONAL blocks for a single
+/// level of `include`.  Calls itself for nested includes.
+#[allow(clippy::too_many_arguments)]
+fn emit_includes(
+    parent_shape: &ModelShape,
+    include: &HashMap<String, IncludeValue>,
+    parent_var: &str,
+    prefix: &str,
+    counter: &mut usize,
+    depth: u8,
+    resolver: &dyn ShapeResolver,
+    construct_lines: &mut Vec<String>,
+    where_lines: &mut Vec<String>,
+) -> Result<(), Error> {
+    if depth >= MAX_CONSTRUCT_DEPTH {
+        log::warn!(
+            "build_construct_sparql: include depth {depth} exceeded MAX_CONSTRUCT_DEPTH {MAX_CONSTRUCT_DEPTH} — truncating",
+        );
+        return Ok(());
+    }
+
+    for (rel_name, val) in include {
+        let rel = match parent_shape.include_relations.iter().find(|r| r.name == *rel_name) {
+            Some(r) => r,
+            None => continue,
+        };
+        if rel.direction == "reverse" || validate_iri(&rel.predicate).is_err() {
+            continue;
+        }
+
+        let target_shape = match resolver.get_shape(&rel.target_class_name) {
+            Ok(s) => s,
+            Err(_) => continue, // missing shape — skip this branch silently
+        };
+
+        let idx = *counter;
+        *counter += 1;
+        let target_var = format!("?{prefix}_{idx}_t");
+        let target_pred_var = format!("?{prefix}_{idx}_p");
+        let target_obj_var = format!("?{prefix}_{idx}_o");
+
+        // CONSTRUCT: link parent → target, then target → its properties
+        construct_lines.push(format!(
+            "    {parent_var} <{}> {target_var} .",
+            rel.predicate
+        ));
+        construct_lines.push(format!(
+            "    {target_var} {target_pred_var} {target_obj_var} ."
+        ));
+
+        // WHERE: wrap the include in OPTIONAL so a missing relation
+        // doesn't drop the parent.  Conformance filter on the target via
+        // its entry-type flag if one exists.
+        let mut opt_lines: Vec<String> = Vec::new();
+        opt_lines.push(format!(
+            "        {parent_var} <{}> {target_var} .",
+            rel.predicate
+        ));
+
+        let target_conformance =
+            build_target_conformance(target_shape.as_ref(), &target_var);
+        for line in target_conformance {
+            opt_lines.push(format!("        {line}"));
+        }
+        opt_lines.push(format!(
+            "        {target_var} {target_pred_var} {target_obj_var} ."
+        ));
+        if let Some(filter) = build_predicate_values(&target_shape.properties, &target_pred_var) {
+            opt_lines.push(format!("        {filter}"));
+        }
+
+        // Nested includes
+        if let IncludeValue::SubQuery(sq) = val {
+            if let Some(nested) = &sq.include {
+                emit_includes(
+                    target_shape.as_ref(),
+                    nested,
+                    &target_var,
+                    &format!("{prefix}_{idx}"),
+                    counter,
+                    depth + 1,
+                    resolver,
+                    construct_lines,
+                    where_lines,
+                )?;
+            }
+        }
+
+        let opt_body = opt_lines.join("\n");
+        where_lines.push(format!("    OPTIONAL {{\n{opt_body}\n    }}"));
+    }
+    Ok(())
+}
+
+/// Produce the SPARQL pattern lines that enforce the target shape's
+/// entry-type conformance — the equivalent of the
+/// `?source <entry_type> <Class>` line at the top of the main shape's
+/// CONSTRUCT body.
+fn build_target_conformance(shape: &ModelShape, target_var: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for prop in &shape.properties {
+        if prop.is_required && prop.is_flag {
+            if let Some(initial) = &prop.initial_value {
+                if validate_iri(&prop.predicate).is_ok() && validate_iri(initial).is_ok() {
+                    out.push(format!(
+                        "{target_var} <{}> <{}> .",
+                        prop.predicate, initial
+                    ));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Walk the triples returned by [`SparqlStore::query_triples`] and
+/// reconstruct the JSON instance tree.
+///
+/// `triples` is the raw subject/predicate/object output where typed RDF
+/// literals have already been wire-format encoded by
+/// `storage_term_to_target_string`.  This walker:
+///
+/// 1. Groups triples by subject (one HashMap pass).
+/// 2. Identifies which subjects are top-level instances of `shape` via the
+///    entry-type flag triple.
+/// 3. For each top-level subject, builds a JSON object whose keys are the
+///    shape's property/relation names, recursively hydrating any included
+///    relation targets via [`hydrate_one`].
+///
+/// Returns instances in the order their `?source` IRIs appear in the
+/// triple stream — which for a CONSTRUCT against an `ORDER BY`-driven
+/// inner SELECT is the requested page order.
+pub(super) fn walk_graph_to_instances(
+    triples: Vec<(String, String, String)>,
+    shape: &ModelShape,
+    query: &ModelQueryInput,
+    resolver: &dyn ShapeResolver,
+) -> Result<Vec<Value>, Error> {
+    // Pass 1: group by subject.  Order-preserving via `Vec` of subjects.
+    let mut by_subject: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    let mut subject_order: Vec<String> = Vec::new();
+    for (s, p, o) in triples {
+        if !by_subject.contains_key(&s) {
+            subject_order.push(s.clone());
+        }
+        by_subject.entry(s).or_default().push((p, o));
+    }
+
+    // Pass 2: filter to subjects matching the top-level shape's conformance flag.
+    let conformance = find_required_flag(shape);
+    let mut top_subjects: Vec<String> = Vec::new();
+    for subj in &subject_order {
+        if subject_matches_shape(&by_subject, subj, shape, &conformance) {
+            top_subjects.push(subj.clone());
+        }
+    }
+
+    // Pass 3: hydrate each top-level subject.  Recurses into includes.
+    let include = query.include.as_ref();
+    let mut out: Vec<Value> = Vec::with_capacity(top_subjects.len());
+    for subj in top_subjects {
+        let inst = hydrate_one(&by_subject, &subj, shape, include, resolver, 0)?;
+        out.push(inst);
+    }
+    Ok(out)
+}
+
+/// Find the `(predicate, value)` of the shape's required-flag triple, if
+/// the shape declares one.  Used to filter the triple stream to top-level
+/// instances of the shape.
+fn find_required_flag(shape: &ModelShape) -> Option<(String, String)> {
+    for prop in &shape.properties {
+        if prop.is_required && prop.is_flag {
+            if let Some(initial) = &prop.initial_value {
+                return Some((prop.predicate.clone(), initial.clone()));
+            }
+        }
+    }
+    None
+}
+
+/// Returns `true` when the given subject has a triple matching the shape's
+/// required-flag conformance pattern, or has *any* triple with a
+/// shape-declared predicate when no flag is present (mirrors the fallback
+/// conformance behaviour in `build_source_selector`).
+fn subject_matches_shape(
+    by_subject: &HashMap<String, Vec<(String, String)>>,
+    subj: &str,
+    shape: &ModelShape,
+    conformance: &Option<(String, String)>,
+) -> bool {
+    let rows = match by_subject.get(subj) {
+        Some(r) => r,
+        None => return false,
+    };
+    if let Some((pred, val)) = conformance {
+        return rows.iter().any(|(p, o)| p == pred && o == val);
+    }
+    let predicates: HashSet<&str> = shape
+        .properties
+        .iter()
+        .map(|p| p.predicate.as_str())
+        .collect();
+    rows.iter().any(|(p, _)| predicates.contains(p.as_str()))
+}
+
+/// Build the JSON object for one subject by mapping its triples onto the
+/// shape's property/relation field names.  Recurses into any include's
+/// target subjects, using `target_class_name` to resolve the target shape
+/// from `resolver`.
+fn hydrate_one(
+    by_subject: &HashMap<String, Vec<(String, String)>>,
+    subj: &str,
+    shape: &ModelShape,
+    include: Option<&HashMap<String, IncludeValue>>,
+    resolver: &dyn ShapeResolver,
+    depth: u8,
+) -> Result<Value, Error> {
+    if depth >= MAX_CONSTRUCT_DEPTH {
+        return Ok(Value::Object(serde_json::Map::new()));
+    }
+    let mut obj = serde_json::Map::new();
+    obj.insert("id".to_string(), Value::String(subj.to_string()));
+
+    let rows = by_subject.get(subj).cloned().unwrap_or_default();
+
+    // ----- Property values -----
+    let mut by_pred: HashMap<String, Vec<String>> = HashMap::new();
+    for (p, o) in &rows {
+        by_pred.entry(p.clone()).or_default().push(o.clone());
+    }
+
+    for prop in &shape.properties {
+        if prop.predicate.is_empty() || prop.is_flag {
+            continue;
+        }
+        let vals = match by_pred.get(&prop.predicate) {
+            Some(v) => v,
+            None => continue,
+        };
+
+        if prop.is_collection || (matches!(prop.direction.as_deref(), Some("forward"))
+            && !prop.is_scalar_relation)
+        {
+            obj.insert(
+                prop.name.clone(),
+                Value::Array(vals.iter().map(|v| Value::String(v.clone())).collect()),
+            );
+        } else if let Some(last) = vals.last() {
+            obj.insert(prop.name.clone(), parse_scalar_value(last, prop));
+        }
+    }
+
+    // Default empty arrays for declared collection properties that had
+    // no triples — matches the legacy hydrator behaviour so consumers can
+    // assume `obj.collection` is always defined.
+    for prop in &shape.properties {
+        if prop.is_collection && !obj.contains_key(&prop.name) {
+            obj.insert(prop.name.clone(), Value::Array(vec![]));
+        }
+    }
+
+    // ----- Includes (forward only, by design of can_use_construct) -----
+    if let Some(include) = include {
+        for (rel_name, val) in include {
+            let want_nested = !matches!(val, IncludeValue::Bool(false));
+            if !want_nested {
+                continue;
+            }
+            let rel = match shape.include_relations.iter().find(|r| r.name == *rel_name) {
+                Some(r) => r,
+                None => continue,
+            };
+            if rel.direction == "reverse" {
+                continue;
+            }
+            let target_shape = match resolver.get_shape(&rel.target_class_name) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            // Find linked subjects via the relation's predicate
+            let linked: Vec<String> = rows
+                .iter()
+                .filter(|(p, _)| p == &rel.predicate)
+                .map(|(_, o)| o.clone())
+                .collect();
+            // Filter to only those that match the target shape (and don't
+            // accidentally pick up triples from sibling relations that share
+            // the predicate — `topicTag` vs `embeddingTag`).
+            let target_conf = find_required_flag(target_shape.as_ref());
+            let nested_include = match val {
+                IncludeValue::SubQuery(sq) => sq.include.as_ref(),
+                _ => None,
+            };
+            let mut nested: Vec<Value> = Vec::new();
+            for tid in &linked {
+                if subject_matches_shape(by_subject, tid, target_shape.as_ref(), &target_conf) {
+                    let child = hydrate_one(
+                        by_subject,
+                        tid,
+                        target_shape.as_ref(),
+                        nested_include,
+                        resolver,
+                        depth + 1,
+                    )?;
+                    nested.push(child);
+                }
+            }
+            if rel.max_count == Some(1) {
+                obj.insert(
+                    rel.name.clone(),
+                    nested.into_iter().next().unwrap_or(Value::Null),
+                );
+            } else {
+                obj.insert(rel.name.clone(), Value::Array(nested));
+            }
+        }
+    }
+
+    Ok(Value::Object(obj))
+}
+
+/// Parse a single wire-format value back to its typed JSON representation.
+/// Mirrors the small subset of `parse_literal_value` we need here:
+/// `literal:string:` → JSON string (unencoded), `literal:number:` →
+/// JSON number when finite, `literal:boolean:` → JSON bool, everything
+/// else → JSON string (used for `literal:json:` and bare IRIs alike).
+fn parse_scalar_value(val: &str, _prop: &ShapeProperty) -> Value {
+    if let Some(rest) = val.strip_prefix("literal:number:") {
+        if let Ok(n) = rest.parse::<f64>() {
+            if let Some(num) = serde_json::Number::from_f64(n) {
+                return Value::Number(num);
+            }
+        }
+        return Value::String(rest.to_string());
+    }
+    if let Some(rest) = val.strip_prefix("literal:boolean:") {
+        return match rest {
+            "true" => Value::Bool(true),
+            "false" => Value::Bool(false),
+            _ => Value::String(rest.to_string()),
+        };
+    }
+    if let Some(rest) = val.strip_prefix("literal:string:") {
+        use percent_encoding::percent_decode_str;
+        let decoded = percent_decode_str(rest)
+            .decode_utf8()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|_| rest.to_string());
+        return Value::String(decoded);
+    }
+    Value::String(val.to_string())
+}

--- a/rust-executor/src/perspectives/model_query/construct_builder.rs
+++ b/rust-executor/src/perspectives/model_query/construct_builder.rs
@@ -209,26 +209,35 @@ pub(super) fn build_construct_sparql(
     query: &ModelQueryInput,
     resolver: &dyn ShapeResolver,
 ) -> Result<Option<String>, Error> {
-    let mut construct_lines: Vec<String> = Vec::new();
-    let mut where_lines: Vec<String> = Vec::new();
+    // Single CONSTRUCT template: `?_subject ?_predicate ?_object .`
+    // Each UNION branch BINDs those three to produce the triples for one
+    // subgraph layer (top-level instance properties, the parent→target
+    // link for each include, the target's own properties, recursively
+    // for nested includes).  Branches don't share bindings — that's the
+    // key fix: the previous "wide WHERE with OPTIONAL" shape produced an
+    // M×N cross-product per source, which on Oxigraph 0.5.x is O(seconds)
+    // even when M and N are small.
 
-    // Inner pagination/scope: SELECT DISTINCT ?source { conformance + where }
-    // LIMIT N.  This is what restricts the CONSTRUCT to the relevant page.
     let inner_select = build_source_selector(shape, query)?;
-    where_lines.push(format!("    {{ {inner_select} }}"));
+    let mut union_branches: Vec<String> = Vec::new();
 
-    // Main instance triples
-    construct_lines.push("    ?source ?_p ?_o .".to_string());
-    let predicate_filter = build_predicate_values(&shape.properties, "?_p");
-    where_lines.push("    ?source ?_p ?_o .".to_string());
-    if let Some(filter) = predicate_filter {
-        where_lines.push(format!("    {filter}"));
+    // Branch 0: top-level instance triples.
+    {
+        let predicate_filter = build_predicate_values(&shape.properties, "?_predicate");
+        let mut lines: Vec<String> = Vec::new();
+        lines.push(format!("        {{ {inner_select} }}"));
+        lines.push("        ?source ?_predicate ?_object .".to_string());
+        if let Some(filter) = predicate_filter {
+            lines.push(format!("        {filter}"));
+        }
+        lines.push("        BIND(?source AS ?_subject)".to_string());
+        union_branches.push(format!("    {{\n{}\n    }}", lines.join("\n")));
     }
 
-    // Recursively emit includes
+    // Recursive include branches.
     if let Some(include) = &query.include {
         let mut counter: usize = 0;
-        emit_includes(
+        emit_include_branches(
             shape,
             include,
             "?source",
@@ -236,16 +245,15 @@ pub(super) fn build_construct_sparql(
             &mut counter,
             0,
             resolver,
-            &mut construct_lines,
-            &mut where_lines,
+            &inner_select,
+            &mut union_branches,
         )?;
     }
 
-    let construct_body = construct_lines.join("\n");
-    let where_body = where_lines.join("\n");
+    let where_body = union_branches.join("\n    UNION\n");
 
     Ok(Some(format!(
-        "CONSTRUCT {{\n{construct_body}\n}}\nWHERE {{\n{where_body}\n}}"
+        "CONSTRUCT {{ ?_subject ?_predicate ?_object . }}\nWHERE {{\n{where_body}\n}}"
     )))
 }
 
@@ -295,24 +303,61 @@ fn build_source_selector(
         }
     }
 
-    // WHERE-clause pushdown: only `id` / `base` equality flavours are
-    // supported here.  Anything else => `can_use_construct` should have
-    // returned false; we'd have fallen back already.  This is the same
-    // subset the legacy `all_where_pushable` handles for the unique-id case.
+    // WHERE-clause pushdown.  Three flavours are supported in the inner
+    // SELECT — anything else makes `can_use_construct` return false:
+    //   1. `id` / `base` equality (`String` or `StringArray`) → VALUES ?source
+    //   2. `id` / `base` Ops (`String(IRI in set)` etc.)  → not handled here yet
+    //   3. scalar-property equality (`String` value) where the property is a
+    //      declared scalar @Property on the shape → adds `?source <pred> <value>`
+    //
+    // Everything else falls into post-hydration Rust filtering in the
+    // legacy pipeline; the CONSTRUCT path bails (`can_use_construct`
+    // returns false) so behaviour stays correct.
     if let Some(wc) = &query.where_clause {
-        if let Some(WhereCondition::String(iri)) = wc.get("id") {
-            if validate_iri(iri).is_ok() {
-                patterns.push(format!("VALUES ?source {{ <{iri}> }}"));
+        for (prop_name, condition) in wc {
+            if prop_name == "id" || prop_name == "base" {
+                match condition {
+                    WhereCondition::String(iri) if validate_iri(iri).is_ok() => {
+                        patterns.push(format!("VALUES ?source {{ <{iri}> }}"));
+                    }
+                    WhereCondition::StringArray(arr) => {
+                        let safe: Vec<String> = arr
+                            .iter()
+                            .filter(|s| validate_iri(s).is_ok())
+                            .map(|s| format!("<{s}>"))
+                            .collect();
+                        if !safe.is_empty() {
+                            patterns.push(format!("VALUES ?source {{ {} }}", safe.join(" ")));
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
             }
-        }
-        if let Some(WhereCondition::StringArray(arr)) = wc.get("id") {
-            let safe: Vec<String> = arr
+            // Scalar-property equality: find the named property on the
+            // shape and emit an `?source <pred> <value>` constraint.  The
+            // value form depends on the property's datatype — for `String`
+            // values that look like absolute IRIs we emit a NamedNode
+            // pattern; otherwise we fall back to the typed-literal form
+            // the storage layer round-trips through.
+            let prop_opt = shape
+                .properties
                 .iter()
-                .filter(|s| validate_iri(s).is_ok())
-                .map(|s| format!("<{s}>"))
-                .collect();
-            if !safe.is_empty() {
-                patterns.push(format!("VALUES ?source {{ {} }}", safe.join(" ")));
+                .find(|p| p.name == *prop_name && !p.is_flag && !p.is_collection);
+            if let Some(prop) = prop_opt {
+                if validate_iri(&prop.predicate).is_err() {
+                    continue;
+                }
+                if let WhereCondition::String(val) = condition {
+                    if validate_iri(val).is_ok() {
+                        // Treat as IRI — same shape as id-eq but on the
+                        // user-specified property predicate.
+                        patterns.push(format!(
+                            "?source <{}> <{val}> .",
+                            prop.predicate
+                        ));
+                    }
+                }
             }
         }
     }
@@ -345,10 +390,24 @@ fn build_predicate_values(props: &[ShapeProperty], var: &str) -> Option<String> 
     }
 }
 
-/// Recursively emit the CONSTRUCT body + WHERE OPTIONAL blocks for a single
-/// level of `include`.  Calls itself for nested includes.
+/// Recursively emit one or more UNION branches for an include map.
+///
+/// Each include produces *two* branches:
+///   - **parent→target link**: one CONSTRUCT triple per matched edge.
+///   - **target properties**: one CONSTRUCT triple per matched target
+///     property triple.
+///
+/// Both branches are gated by the SAME `?source` restriction (the inner
+/// SELECT shared across branches) so the planner can hash-join once and
+/// then emit each branch independently.  Nested includes recurse into
+/// their own branches in turn — depth N includes produce 2N branches
+/// each rooted on the same `?source` restriction.
+///
+/// The shared `inner_select` is duplicated into each branch as a
+/// `{ … }` sub-pattern; Oxigraph 0.5.x dedups identical sub-queries at
+/// plan time so the actual conformance scan runs once.
 #[allow(clippy::too_many_arguments)]
-fn emit_includes(
+fn emit_include_branches(
     parent_shape: &ModelShape,
     include: &HashMap<String, IncludeValue>,
     parent_var: &str,
@@ -356,8 +415,8 @@ fn emit_includes(
     counter: &mut usize,
     depth: u8,
     resolver: &dyn ShapeResolver,
-    construct_lines: &mut Vec<String>,
-    where_lines: &mut Vec<String>,
+    inner_select: &str,
+    union_branches: &mut Vec<String>,
 ) -> Result<(), Error> {
     if depth >= MAX_CONSTRUCT_DEPTH {
         log::warn!(
@@ -377,49 +436,58 @@ fn emit_includes(
 
         let target_shape = match resolver.get_shape(&rel.target_class_name) {
             Ok(s) => s,
-            Err(_) => continue, // missing shape — skip this branch silently
+            Err(_) => continue,
         };
 
         let idx = *counter;
         *counter += 1;
         let target_var = format!("?{prefix}_{idx}_t");
-        let target_pred_var = format!("?{prefix}_{idx}_p");
-        let target_obj_var = format!("?{prefix}_{idx}_o");
 
-        // CONSTRUCT: link parent → target, then target → its properties
-        construct_lines.push(format!(
-            "    {parent_var} <{}> {target_var} .",
-            rel.predicate
-        ));
-        construct_lines.push(format!(
-            "    {target_var} {target_pred_var} {target_obj_var} ."
-        ));
+        let target_conformance = build_target_conformance(target_shape.as_ref(), &target_var);
 
-        // WHERE: wrap the include in OPTIONAL so a missing relation
-        // doesn't drop the parent.  Conformance filter on the target via
-        // its entry-type flag if one exists.
-        let mut opt_lines: Vec<String> = Vec::new();
-        opt_lines.push(format!(
-            "        {parent_var} <{}> {target_var} .",
-            rel.predicate
-        ));
-
-        let target_conformance =
-            build_target_conformance(target_shape.as_ref(), &target_var);
-        for line in target_conformance {
-            opt_lines.push(format!("        {line}"));
-        }
-        opt_lines.push(format!(
-            "        {target_var} {target_pred_var} {target_obj_var} ."
-        ));
-        if let Some(filter) = build_predicate_values(&target_shape.properties, &target_pred_var) {
-            opt_lines.push(format!("        {filter}"));
+        // Branch A: parent→target link itself.
+        {
+            let mut lines: Vec<String> = Vec::new();
+            lines.push(format!("        {{ {inner_select} }}"));
+            lines.push(format!(
+                "        {parent_var} <{}> {target_var} .",
+                rel.predicate
+            ));
+            for line in &target_conformance {
+                lines.push(format!("        {line}"));
+            }
+            lines.push(format!(
+                "        BIND({parent_var} AS ?_subject) BIND(<{}> AS ?_predicate) BIND({target_var} AS ?_object)",
+                rel.predicate
+            ));
+            union_branches.push(format!("    {{\n{}\n    }}", lines.join("\n")));
         }
 
-        // Nested includes
+        // Branch B: target's own property triples.
+        {
+            let predicate_filter =
+                build_predicate_values(&target_shape.properties, "?_predicate");
+            let mut lines: Vec<String> = Vec::new();
+            lines.push(format!("        {{ {inner_select} }}"));
+            lines.push(format!(
+                "        {parent_var} <{}> {target_var} .",
+                rel.predicate
+            ));
+            for line in &target_conformance {
+                lines.push(format!("        {line}"));
+            }
+            lines.push(format!("        {target_var} ?_predicate ?_object ."));
+            if let Some(filter) = predicate_filter {
+                lines.push(format!("        {filter}"));
+            }
+            lines.push(format!("        BIND({target_var} AS ?_subject)"));
+            union_branches.push(format!("    {{\n{}\n    }}", lines.join("\n")));
+        }
+
+        // Nested includes (recurse).
         if let IncludeValue::SubQuery(sq) = val {
             if let Some(nested) = &sq.include {
-                emit_includes(
+                emit_include_branches(
                     target_shape.as_ref(),
                     nested,
                     &target_var,
@@ -427,14 +495,11 @@ fn emit_includes(
                     counter,
                     depth + 1,
                     resolver,
-                    construct_lines,
-                    where_lines,
+                    inner_select,
+                    union_branches,
                 )?;
             }
         }
-
-        let opt_body = opt_lines.join("\n");
-        where_lines.push(format!("    OPTIONAL {{\n{opt_body}\n    }}"));
     }
     Ok(())
 }

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -4615,3 +4615,195 @@ async fn test_aggregate_createdAt_updatedAt_from_sparql() {
         "aggregate updatedAt mismatch — {agg_rows:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Construct-builder (audit item I) integration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_can_use_construct_default_off() {
+    // Without `useConstruct: true` the path stays off, even when every
+    // other condition is satisfied.
+    let shape = super::test_helpers::shape(
+        "Topic",
+        vec![
+            super::test_helpers::flag("type", "flux://entry_type", "flux://has_topic"),
+            super::test_helpers::prop("label", "flux://topic"),
+        ],
+    );
+    let q = ModelQueryInput {
+        with_metadata: Some(false),
+        count: Some(false),
+        ..Default::default()
+    };
+    assert!(
+        !super::construct_builder::can_use_construct(&q, &shape),
+        "can_use_construct should default off without explicit useConstruct"
+    );
+}
+
+#[test]
+fn test_can_use_construct_engages_on_simple_query() {
+    let shape = super::test_helpers::shape(
+        "Topic",
+        vec![
+            super::test_helpers::flag("type", "flux://entry_type", "flux://has_topic"),
+            super::test_helpers::prop("label", "flux://topic"),
+        ],
+    );
+    let q = ModelQueryInput {
+        with_metadata: Some(false),
+        count: Some(false),
+        use_construct: Some(true),
+        ..Default::default()
+    };
+    assert!(
+        super::construct_builder::can_use_construct(&q, &shape),
+        "can_use_construct should engage when all conditions met"
+    );
+}
+
+#[test]
+fn test_can_use_construct_disqualifies_with_metadata() {
+    let shape = super::test_helpers::shape(
+        "Topic",
+        vec![super::test_helpers::flag("type", "flux://entry_type", "flux://has_topic")],
+    );
+    let q = ModelQueryInput {
+        with_metadata: Some(true), // disqualifier #7
+        count: Some(false),
+        use_construct: Some(true),
+        ..Default::default()
+    };
+    assert!(
+        !super::construct_builder::can_use_construct(&q, &shape),
+        "withMetadata: true should disqualify the CONSTRUCT path"
+    );
+}
+
+#[test]
+fn test_can_use_construct_disqualifies_projections() {
+    let shape = super::test_helpers::shape(
+        "Topic",
+        vec![super::test_helpers::flag("type", "flux://entry_type", "flux://has_topic")],
+    );
+    let mut projections: std::collections::HashMap<String, ProjectionInput> =
+        std::collections::HashMap::new();
+    projections.insert(
+        "$nope".to_string(),
+        ProjectionInput {
+            from: "label".to_string(),
+            count: true,
+            limit: None,
+            order: None,
+            target_class_name: None,
+            where_clause: None,
+        },
+    );
+    let q = ModelQueryInput {
+        projections: Some(projections),
+        with_metadata: Some(false),
+        count: Some(false),
+        use_construct: Some(true),
+        ..Default::default()
+    };
+    assert!(
+        !super::construct_builder::can_use_construct(&q, &shape),
+        "non-empty projections should disqualify CONSTRUCT path"
+    );
+}
+
+#[tokio::test]
+async fn test_construct_path_resolves_simple_query() {
+    let store = SparqlStore::new(None).unwrap();
+
+    let t1 = "literal:string:topic1";
+    let t2 = "literal:string:topic2";
+
+    // Two Topic instances
+    store
+        .add_link(&make_link(t1, "flux://entry_type", "flux://has_topic", "1700000000000"))
+        .unwrap();
+    store
+        .add_link(&make_link(
+            t1,
+            "flux://topic",
+            &format!("literal:string:{}", literal_percent_encode("Hello")),
+            "1700000000001",
+        ))
+        .unwrap();
+    store
+        .add_link(&make_link(t2, "flux://entry_type", "flux://has_topic", "1700000000002"))
+        .unwrap();
+    store
+        .add_link(&make_link(
+            t2,
+            "flux://topic",
+            &format!("literal:string:{}", literal_percent_encode("World")),
+            "1700000000003",
+        ))
+        .unwrap();
+
+    // Sanity check via the legacy pipeline
+    let shape_json = r#"{
+        "className": "Topic",
+        "properties": {
+            "type": {
+                "predicate": "flux://entry_type",
+                "required": true,
+                "flag": true,
+                "initial": "flux://has_topic"
+            },
+            "label": { "predicate": "flux://topic", "required": false }
+        },
+        "relations": {}
+    }"#;
+    let legacy = execute_model_query_from_json(
+        &store,
+        "Topic",
+        &ModelQueryInput {
+            with_metadata: Some(false),
+            count: Some(false),
+            ..Default::default()
+        },
+        shape_json,
+    )
+    .await
+    .unwrap();
+    assert_eq!(legacy.instances.len(), 2, "legacy path should find 2 topics");
+
+    // Now the CONSTRUCT path on the same store/shape — same result expected
+    let construct = execute_model_query_from_json(
+        &store,
+        "Topic",
+        &ModelQueryInput {
+            with_metadata: Some(false),
+            count: Some(false),
+            use_construct: Some(true),
+            ..Default::default()
+        },
+        shape_json,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        construct.instances.len(),
+        2,
+        "CONSTRUCT path should find 2 topics — same as legacy"
+    );
+
+    // Both instances should have a `label` field that matches one of the
+    // seeded values.  The walker decodes percent-encoded literals.
+    let mut labels: Vec<String> = construct
+        .instances
+        .iter()
+        .filter_map(|i| i["label"].as_str().map(|s| s.to_string()))
+        .collect();
+    labels.sort();
+    assert_eq!(
+        labels,
+        vec!["Hello".to_string(), "World".to_string()],
+        "label fields should round-trip through the wire-format decoder"
+    );
+}
+

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -4667,7 +4667,11 @@ fn test_can_use_construct_engages_on_simple_query() {
 fn test_can_use_construct_disqualifies_with_metadata() {
     let shape = super::test_helpers::shape(
         "Topic",
-        vec![super::test_helpers::flag("type", "flux://entry_type", "flux://has_topic")],
+        vec![super::test_helpers::flag(
+            "type",
+            "flux://entry_type",
+            "flux://has_topic",
+        )],
     );
     let q = ModelQueryInput {
         with_metadata: Some(true), // disqualifier #7
@@ -4685,7 +4689,11 @@ fn test_can_use_construct_disqualifies_with_metadata() {
 fn test_can_use_construct_disqualifies_projections() {
     let shape = super::test_helpers::shape(
         "Topic",
-        vec![super::test_helpers::flag("type", "flux://entry_type", "flux://has_topic")],
+        vec![super::test_helpers::flag(
+            "type",
+            "flux://entry_type",
+            "flux://has_topic",
+        )],
     );
     let mut projections: std::collections::HashMap<String, ProjectionInput> =
         std::collections::HashMap::new();
@@ -4722,7 +4730,12 @@ async fn test_construct_path_resolves_simple_query() {
 
     // Two Topic instances
     store
-        .add_link(&make_link(t1, "flux://entry_type", "flux://has_topic", "1700000000000"))
+        .add_link(&make_link(
+            t1,
+            "flux://entry_type",
+            "flux://has_topic",
+            "1700000000000",
+        ))
         .unwrap();
     store
         .add_link(&make_link(
@@ -4733,7 +4746,12 @@ async fn test_construct_path_resolves_simple_query() {
         ))
         .unwrap();
     store
-        .add_link(&make_link(t2, "flux://entry_type", "flux://has_topic", "1700000000002"))
+        .add_link(&make_link(
+            t2,
+            "flux://entry_type",
+            "flux://has_topic",
+            "1700000000002",
+        ))
         .unwrap();
     store
         .add_link(&make_link(
@@ -4770,7 +4788,11 @@ async fn test_construct_path_resolves_simple_query() {
     )
     .await
     .unwrap();
-    assert_eq!(legacy.instances.len(), 2, "legacy path should find 2 topics");
+    assert_eq!(
+        legacy.instances.len(),
+        2,
+        "legacy path should find 2 topics"
+    );
 
     // Now the CONSTRUCT path on the same store/shape — same result expected
     let construct = execute_model_query_from_json(
@@ -4806,4 +4828,3 @@ async fn test_construct_path_resolves_simple_query() {
         "label fields should round-trip through the wire-format decoder"
     );
 }
-

--- a/rust-executor/src/perspectives/model_query/mod.rs
+++ b/rust-executor/src/perspectives/model_query/mod.rs
@@ -80,6 +80,7 @@
 //! | [`projection`] | Computing projection aggregations (counts and filtered lists) |
 //! | [`query`] | Top-level orchestrator that wires the whole pipeline together |
 
+mod construct_builder;
 mod eval_transform;
 mod filtering;
 mod getters;

--- a/rust-executor/src/perspectives/model_query/projection.rs
+++ b/rust-executor/src/perspectives/model_query/projection.rs
@@ -188,7 +188,9 @@ pub(super) async fn resolve_projections(
                 let n: u64 = row
                     .get(&col)
                     .and_then(|v| {
-                        v.as_str().and_then(|s| s.parse().ok()).or_else(|| v.as_u64())
+                        v.as_str()
+                            .and_then(|s| s.parse().ok())
+                            .or_else(|| v.as_u64())
                     })
                     .unwrap_or(0);
                 by_parent.insert(parent, n);
@@ -228,16 +230,15 @@ pub(super) async fn resolve_projections(
 
     let list_results: Vec<Result<Vec<Value>, deno_core::anyhow::Error>> =
         futures::future::join_all(
-            list_sparqls.iter().map(|(_, sparql)| store.query_values_async(sparql)),
+            list_sparqls
+                .iter()
+                .map(|(_, sparql)| store.query_values_async(sparql)),
         )
         .await;
 
     // ---- Stage 4: attach count results to instances ----
     for rp in &count_projs {
-        let map = count_results
-            .get(&rp.key)
-            .cloned()
-            .unwrap_or_default();
+        let map = count_results.get(&rp.key).cloned().unwrap_or_default();
         for inst in instances.iter_mut() {
             if let Some(obj) = inst.as_object_mut() {
                 let id = obj
@@ -302,8 +303,7 @@ pub(super) async fn resolve_projections(
 
                     if !all_ids.is_empty() {
                         let mut sub_where = BTreeMap::new();
-                        sub_where
-                            .insert("id".to_string(), WhereCondition::StringArray(all_ids));
+                        sub_where.insert("id".to_string(), WhereCondition::StringArray(all_ids));
                         let sub_query = ModelQueryInput {
                             where_clause: Some(sub_where),
                             deep_query: Some(true),
@@ -384,10 +384,7 @@ pub(super) async fn resolve_projections(
 /// `parts` is `(safe_pred, where_patterns, reifier_patterns)` per
 /// projection in iteration order.  See [`resolve_projections`] for the
 /// surrounding pipeline.
-fn build_fused_count_sparql(
-    parts: &[(String, String, String)],
-    values_clause: &str,
-) -> String {
+fn build_fused_count_sparql(parts: &[(String, String, String)], values_clause: &str) -> String {
     let mut select_cols = String::from("?source");
     let mut option_blocks = String::new();
     for (i, (pred, wp, rp_pat)) in parts.iter().enumerate() {
@@ -697,11 +694,7 @@ mod fused_count_tests {
 
     #[test]
     fn fused_count_single_projection_is_well_formed() {
-        let parts = vec![(
-            "flux://has_tag".to_string(),
-            String::new(),
-            String::new(),
-        )];
+        let parts = vec![("flux://has_tag".to_string(), String::new(), String::new())];
         let s = build_fused_count_sparql(&parts, "<a:1> <a:2>");
         assert!(s.contains("SELECT ?source ?_count_0 WHERE"));
         assert!(s.contains("VALUES ?source { <a:1> <a:2> }"));
@@ -734,8 +727,14 @@ mod fused_count_tests {
         let s = "?source <p> ?t . FILTER(?target = <x>)";
         let out = rewrite_var(s, "?t", "?_t_0", "?parent", "?source");
         assert!(out.contains("?_t_0"), "out={out}");
-        assert!(out.contains("?target"), "`?target` should remain untouched: out={out}");
-        assert!(!out.contains("?_t_0arget"), "must not splice mid-word: out={out}");
+        assert!(
+            out.contains("?target"),
+            "`?target` should remain untouched: out={out}"
+        );
+        assert!(
+            !out.contains("?_t_0arget"),
+            "must not splice mid-word: out={out}"
+        );
     }
 
     #[test]

--- a/rust-executor/src/perspectives/model_query/projection.rs
+++ b/rust-executor/src/perspectives/model_query/projection.rs
@@ -44,13 +44,27 @@ use crate::perspectives::sparql_store::SparqlStore;
 
 /// Resolve all projections for a set of parent instances.
 ///
-/// For each projection key, builds and executes a single grouped SPARQL
-/// query that collects either counts or target IRI lists, then merges the
-/// results into the instance objects.
+/// Two-stage pipeline (audit item **H**):
 ///
-/// When `proj.target_shape` is set, raw target IRIs are replaced with fully
-/// hydrated model instances via a recursive `execute_model_query_inner` call
-/// (one batch per projection key, eliminating TS-side round-trips).
+/// 1. **Count projections fold into one fused SELECT.**  Each count
+///    projection contributes a `?source ?_count_<i>` column via an
+///    `OPTIONAL { { SELECT ?source (COUNT(?_t_<i>) AS ?_count_<i>) WHERE
+///    { ?source <pred_<i>> ?_t_<i> . [extras] } GROUP BY ?source } }`
+///    block.  All counts resolve in one round trip.
+///
+/// 2. **List projections fire as parallel futures.**  Each list projection
+///    keeps its own SPARQL (the multi-row binding shape and per-projection
+///    LIMIT/ORDER don't fold cleanly into a single SELECT) but every list
+///    query is launched together via `futures::future::join_all`, so the
+///    wall-clock cost is `max(...)` instead of `sum(...)` of the
+///    per-projection latencies.  The fused count query joins them at the
+///    front of the batch.
+///
+/// When `proj.target_shape` is set, raw target IRIs are replaced with
+/// fully hydrated model instances via a recursive `execute_model_query_inner`
+/// call.  Target hydration happens *after* the parallel SPARQL phase
+/// completes — it can't fold into the fused query because the recursive
+/// pipeline needs the collected IRIs first.
 pub(super) async fn resolve_projections(
     store: &SparqlStore,
     instances: &mut Vec<Value>,
@@ -79,6 +93,23 @@ pub(super) async fn resolve_projections(
         .collect::<Vec<_>>()
         .join(" ");
 
+    // ---- Stage 1: split projections into count vs list buckets ----
+    //
+    // We can't pre-build SPARQL until we've resolved predicates against
+    // the shape, so first we collect the resolved metadata for each
+    // projection key.  Anything that fails resolution (missing relation,
+    // invalid predicate IRI, etc.) gets logged + skipped here so the
+    // later stages only see well-formed inputs.
+    struct ResolvedProj<'a> {
+        key: String,
+        proj: &'a ProjectionInput,
+        safe_pred: String,
+        where_patterns: String,
+        reifier_patterns: String,
+    }
+    let mut count_projs: Vec<ResolvedProj> = Vec::new();
+    let mut list_projs: Vec<ResolvedProj> = Vec::new();
+
     for (key, proj) in projections {
         let predicate = match shape.properties.iter().find(|p| p.name == proj.from) {
             Some(p) if !p.predicate.is_empty() => p.predicate.clone(),
@@ -99,7 +130,6 @@ pub(super) async fn resolve_projections(
                 continue;
             }
         };
-
         let safe_pred = match validate_iri(&predicate) {
             Ok(p) => p.to_string(),
             Err(_) => {
@@ -111,53 +141,72 @@ pub(super) async fn resolve_projections(
                 continue;
             }
         };
-
         let where_patterns = build_projection_where_patterns(proj, resolver);
         let reifier_patterns = build_projection_reifier_patterns(proj, &safe_pred);
-
+        let resolved = ResolvedProj {
+            key: key.clone(),
+            proj,
+            safe_pred,
+            where_patterns,
+            reifier_patterns,
+        };
         if proj.count {
-            let sparql = format!(
-                concat!(
-                    "SELECT ?parent (COUNT(DISTINCT ?t) AS ?n) WHERE {{\n",
-                    "    VALUES ?parent {{ {values_clause} }}\n",
-                    "    ?parent <{safe_pred}> ?t .\n",
-                    "{where_patterns}",
-                    "{reifier_patterns}",
-                    "}} GROUP BY ?parent"
-                ),
-                values_clause = values_clause,
-                safe_pred = safe_pred,
-                where_patterns = where_patterns,
-                reifier_patterns = reifier_patterns,
-            );
-
-            let rows = store.query_values(&sparql)?;
-
-            let mut count_map: HashMap<String, u64> = HashMap::new();
-            for row in &rows {
-                let parent = row["parent"].as_str().unwrap_or("").to_string();
-                let n: u64 = row["n"]
-                    .as_str()
-                    .and_then(|s| s.parse().ok())
-                    .or_else(|| row["n"].as_u64())
-                    .unwrap_or(0);
-                count_map.insert(parent, n);
-            }
-
-            for inst in instances.iter_mut() {
-                if let Some(obj) = inst.as_object_mut() {
-                    let id = obj
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let cnt = count_map.get(&id).copied().unwrap_or(0);
-                    obj.insert(key.clone(), Value::Number(cnt.into()));
-                }
-            }
+            count_projs.push(resolved);
         } else {
-            let order_clause = build_projection_order_clause(proj);
+            list_projs.push(resolved);
+        }
+    }
 
+    // ---- Stage 2: fused count query (one round trip for all counts) ----
+    //
+    // Each count projection contributes an OPTIONAL sub-SELECT.  When
+    // there's only one count, the wrapping SELECT degenerates to the
+    // historical shape — no overhead.  When there are several, we save
+    // one round trip per count beyond the first.
+    let mut count_results: HashMap<String, HashMap<String, u64>> = HashMap::new();
+    if !count_projs.is_empty() {
+        let count_parts: Vec<(String, String, String)> = count_projs
+            .iter()
+            .map(|rp| {
+                (
+                    rp.safe_pred.clone(),
+                    rp.where_patterns.clone(),
+                    rp.reifier_patterns.clone(),
+                )
+            })
+            .collect();
+        let fused_sparql = build_fused_count_sparql(&count_parts, &values_clause);
+        let rows = store.query_values_async(&fused_sparql).await?;
+        for (i, rp) in count_projs.iter().enumerate() {
+            let col = format!("_count_{i}");
+            let mut by_parent: HashMap<String, u64> = HashMap::new();
+            for row in &rows {
+                let parent = row["source"].as_str().unwrap_or("").to_string();
+                if parent.is_empty() {
+                    continue;
+                }
+                let n: u64 = row
+                    .get(&col)
+                    .and_then(|v| {
+                        v.as_str().and_then(|s| s.parse().ok()).or_else(|| v.as_u64())
+                    })
+                    .unwrap_or(0);
+                by_parent.insert(parent, n);
+            }
+            count_results.insert(rp.key.clone(), by_parent);
+        }
+    }
+
+    // ---- Stage 3: parallel list-projection queries ----
+    //
+    // Each list projection builds its own SPARQL and we launch them all
+    // concurrently via `futures::future::join_all`.  The store's
+    // `query_values_async` uses `spawn_blocking` internally, so this
+    // produces real wall-clock parallelism on the blocking thread pool.
+    let list_sparqls: Vec<(String, String)> = list_projs
+        .iter()
+        .map(|rp| {
+            let order_clause = build_projection_order_clause(rp.proj);
             let sparql = format!(
                 concat!(
                     "SELECT ?parent ?t WHERE {{\n",
@@ -168,83 +217,122 @@ pub(super) async fn resolve_projections(
                     "}}{order_clause}"
                 ),
                 values_clause = values_clause,
-                safe_pred = safe_pred,
-                where_patterns = where_patterns,
-                reifier_patterns = reifier_patterns,
+                safe_pred = rp.safe_pred,
+                where_patterns = rp.where_patterns,
+                reifier_patterns = rp.reifier_patterns,
                 order_clause = order_clause,
             );
+            (rp.key.clone(), sparql)
+        })
+        .collect();
 
-            let rows = store.query_values(&sparql)?;
+    let list_results: Vec<Result<Vec<Value>, deno_core::anyhow::Error>> =
+        futures::future::join_all(
+            list_sparqls.iter().map(|(_, sparql)| store.query_values_async(sparql)),
+        )
+        .await;
 
-            let mut list_map: HashMap<String, Vec<Value>> = HashMap::new();
-            for row in &rows {
-                if let Some(parent) = row["parent"].as_str() {
-                    let t = row["t"]
-                        .as_str()
-                        .map(|s| Value::String(s.to_string()))
-                        .unwrap_or(Value::Null);
-                    list_map.entry(parent.to_string()).or_default().push(t);
-                }
+    // ---- Stage 4: attach count results to instances ----
+    for rp in &count_projs {
+        let map = count_results
+            .get(&rp.key)
+            .cloned()
+            .unwrap_or_default();
+        for inst in instances.iter_mut() {
+            if let Some(obj) = inst.as_object_mut() {
+                let id = obj
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let cnt = map.get(&id).copied().unwrap_or(0);
+                obj.insert(rp.key.clone(), Value::Number(cnt.into()));
             }
+        }
+    }
 
-            // ----------------------------------------------------------------
-            // 4. If a target class is named, hydrate raw IRIs → full model
-            //    instances in-process — no TS round-trip required. The
-            //    target shape is resolved through the in-perspective
-            //    `ShapeResolver` (cache-backed since PR #827), which keeps
-            //    SHACL the single source of truth across the recursion.
-            // ----------------------------------------------------------------
-            if let Some(ref target_class) = proj.target_class_name {
-                if !proj.count && !target_class.is_empty() {
-                    if let Ok(target_shape) = resolver.get_shape(target_class) {
-                        // Collect all unique raw IRI strings.
-                        let mut seen = std::collections::HashSet::new();
-                        let mut all_ids: Vec<String> = Vec::new();
-                        for vals in list_map.values() {
-                            for v in vals {
-                                if let Some(s) = v.as_str() {
-                                    if seen.insert(s.to_string()) {
-                                        all_ids.push(s.to_string());
-                                    }
+    // ---- Stage 5: build list maps from the join_all results ----
+    let mut list_maps: HashMap<String, HashMap<String, Vec<Value>>> = HashMap::new();
+    for ((key, _), result) in list_sparqls.iter().zip(list_results.into_iter()) {
+        let rows = match result {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("List projection '{key}' failed: {e}");
+                continue;
+            }
+        };
+        let mut list_map: HashMap<String, Vec<Value>> = HashMap::new();
+        for row in &rows {
+            if let Some(parent) = row["parent"].as_str() {
+                let t = row["t"]
+                    .as_str()
+                    .map(|s| Value::String(s.to_string()))
+                    .unwrap_or(Value::Null);
+                list_map.entry(parent.to_string()).or_default().push(t);
+            }
+        }
+        list_maps.insert(key.clone(), list_map);
+    }
+
+    // ---- Stage 6: list-projection post-processing (target hydration + attach) ----
+    //
+    // Target hydration runs sequentially because it recurses into the
+    // shared pipeline — parallelising recursion would let two callers
+    // race the same shape cache.  The parallel cost was in the outer
+    // SPARQL queries above, which are already done.
+    for rp in &list_projs {
+        let key = &rp.key;
+        let proj = rp.proj;
+        let mut list_map = list_maps.remove(key).unwrap_or_default();
+
+        if let Some(ref target_class) = proj.target_class_name {
+            if !target_class.is_empty() {
+                if let Ok(target_shape) = resolver.get_shape(target_class) {
+                    let mut seen = std::collections::HashSet::new();
+                    let mut all_ids: Vec<String> = Vec::new();
+                    for vals in list_map.values() {
+                        for v in vals {
+                            if let Some(s) = v.as_str() {
+                                if seen.insert(s.to_string()) {
+                                    all_ids.push(s.to_string());
                                 }
                             }
                         }
+                    }
 
-                        if !all_ids.is_empty() {
-                            let mut sub_where = BTreeMap::new();
-                            sub_where
-                                .insert("id".to_string(), WhereCondition::StringArray(all_ids));
-                            let sub_query = ModelQueryInput {
-                                where_clause: Some(sub_where),
-                                deep_query: Some(true),
-                                ..ModelQueryInput::default()
-                            };
+                    if !all_ids.is_empty() {
+                        let mut sub_where = BTreeMap::new();
+                        sub_where
+                            .insert("id".to_string(), WhereCondition::StringArray(all_ids));
+                        let sub_query = ModelQueryInput {
+                            where_clause: Some(sub_where),
+                            deep_query: Some(true),
+                            ..ModelQueryInput::default()
+                        };
 
-                            if let Ok(result) = Box::pin(super::query::execute_model_query_inner(
-                                store,
-                                &target_shape,
-                                &sub_query,
-                                resolver,
-                                depth + 1,
-                            ))
-                            .await
-                            {
-                                let hydrated: HashMap<String, Value> = result
-                                    .instances
-                                    .into_iter()
-                                    .filter_map(|inst| {
-                                        let id = inst["id"].as_str()?.to_string();
-                                        Some((id, inst))
-                                    })
-                                    .collect();
+                        if let Ok(result) = Box::pin(super::query::execute_model_query_inner(
+                            store,
+                            &target_shape,
+                            &sub_query,
+                            resolver,
+                            depth + 1,
+                        ))
+                        .await
+                        {
+                            let hydrated: HashMap<String, Value> = result
+                                .instances
+                                .into_iter()
+                                .filter_map(|inst| {
+                                    let id = inst["id"].as_str()?.to_string();
+                                    Some((id, inst))
+                                })
+                                .collect();
 
-                                // Replace raw IRI strings with hydrated objects.
-                                for vals in list_map.values_mut() {
-                                    for v in vals.iter_mut() {
-                                        if let Some(id) = v.as_str() {
-                                            if let Some(obj) = hydrated.get(id) {
-                                                *v = obj.clone();
-                                            }
+                            for vals in list_map.values_mut() {
+                                for v in vals.iter_mut() {
+                                    if let Some(id) = v.as_str() {
+                                        if let Some(obj) = hydrated.get(id) {
+                                            *v = obj.clone();
                                         }
                                     }
                                 }
@@ -253,37 +341,124 @@ pub(super) async fn resolve_projections(
                     }
                 }
             }
+        }
 
-            for inst in instances.iter_mut() {
-                if let Some(obj) = inst.as_object_mut() {
-                    let id = obj
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let val = match proj.limit {
-                        Some(1) => list_map
+        for inst in instances.iter_mut() {
+            if let Some(obj) = inst.as_object_mut() {
+                let id = obj
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let val = match proj.limit {
+                    Some(1) => list_map
+                        .get(&id)
+                        .and_then(|v| v.first().cloned())
+                        .unwrap_or(Value::Null),
+                    Some(n) => Value::Array(
+                        list_map
                             .get(&id)
-                            .and_then(|v| v.first().cloned())
-                            .unwrap_or(Value::Null),
-                        Some(n) => Value::Array(
-                            list_map
-                                .get(&id)
-                                .cloned()
-                                .unwrap_or_default()
-                                .into_iter()
-                                .take(n)
-                                .collect(),
-                        ),
-                        None => Value::Array(list_map.get(&id).cloned().unwrap_or_default()),
-                    };
-                    obj.insert(key.clone(), val);
-                }
+                            .cloned()
+                            .unwrap_or_default()
+                            .into_iter()
+                            .take(n)
+                            .collect(),
+                    ),
+                    None => Value::Array(list_map.get(&id).cloned().unwrap_or_default()),
+                };
+                obj.insert(key.clone(), val);
             }
         }
     }
 
     Ok(())
+}
+
+/// Build one fused SELECT containing N sub-SELECT count blocks.  Each
+/// projection contributes an `OPTIONAL { { SELECT ?source (COUNT(?_t_<i>)
+/// AS ?_count_<i>) WHERE { ?source <pred_<i>> ?_t_<i> . [where_extras]
+/// [reifier_extras] } GROUP BY ?source } }` block.  When there's only
+/// one count projection, the wrapping SELECT degenerates to a single
+/// sub-block with a stable column name — semantically identical to the
+/// historical per-projection SELECT.
+/// `parts` is `(safe_pred, where_patterns, reifier_patterns)` per
+/// projection in iteration order.  See [`resolve_projections`] for the
+/// surrounding pipeline.
+fn build_fused_count_sparql(
+    parts: &[(String, String, String)],
+    values_clause: &str,
+) -> String {
+    let mut select_cols = String::from("?source");
+    let mut option_blocks = String::new();
+    for (i, (pred, wp, rp_pat)) in parts.iter().enumerate() {
+        let col = format!("?_count_{i}");
+        select_cols.push(' ');
+        select_cols.push_str(&col);
+        let wp_rewritten = rewrite_var(wp, "?t", &format!("?_t_{i}"), "?parent", "?source");
+        let rp_rewritten = rewrite_var(rp_pat, "?t", &format!("?_t_{i}"), "?parent", "?source");
+        option_blocks.push_str(&format!(
+            concat!(
+                "    OPTIONAL {{\n",
+                "        {{ SELECT ?source (COUNT(DISTINCT ?_t_{i}) AS {col}) WHERE {{\n",
+                "            ?source <{pred}> ?_t_{i} .\n",
+                "{wp}",
+                "{rp}",
+                "        }} GROUP BY ?source }}\n",
+                "    }}\n"
+            ),
+            i = i,
+            col = col,
+            pred = pred,
+            wp = wp_rewritten,
+            rp = rp_rewritten,
+        ));
+    }
+    format!(
+        concat!(
+            "SELECT {sel} WHERE {{\n",
+            "    VALUES ?source {{ {vc} }}\n",
+            "{blocks}",
+            "}}",
+        ),
+        sel = select_cols,
+        vc = values_clause,
+        blocks = option_blocks,
+    )
+}
+
+/// `build_projection_where_patterns` and `build_projection_reifier_patterns`
+/// were written against `?t` (target) and `?parent` (source) variable
+/// names.  The fused query renumbers per-projection variables so each
+/// sub-SELECT scope owns its own `?_t_<i>` — we have to rewrite the
+/// emitted patterns to match.  Naïve string substitution would also touch
+/// `?target` etc., so this rewrite is whole-word-aware via a regex-like
+/// scan.
+fn rewrite_var(s: &str, old1: &str, new1: &str, old2: &str, new2: &str) -> String {
+    fn rep(s: &str, old: &str, new: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut rest = s;
+        while !rest.is_empty() {
+            if rest.starts_with(old) {
+                let after = &rest[old.len()..];
+                let is_boundary = after
+                    .chars()
+                    .next()
+                    .map_or(true, |c| !c.is_alphanumeric() && c != '_');
+                if is_boundary {
+                    out.push_str(new);
+                    rest = after;
+                    continue;
+                }
+            }
+            let mut chars = rest.chars();
+            if let Some(c) = chars.next() {
+                out.push(c);
+                rest = chars.as_str();
+            }
+        }
+        out
+    }
+    rep(&rep(s, old1, new1), old2, new2)
 }
 
 /// Build SPARQL where-clause patterns for a projection's `where` filter.
@@ -516,6 +691,63 @@ pub(super) fn build_projection_order_clause(proj: &ProjectionInput) -> String {
 /// When the projection's where clause includes `author` or `timestamp`
 /// conditions, this generates triple patterns that join against the RDF 1.2
 /// reifier (the statement that records who created the link and when).
+#[cfg(test)]
+mod fused_count_tests {
+    use super::*;
+
+    #[test]
+    fn fused_count_single_projection_is_well_formed() {
+        let parts = vec![(
+            "flux://has_tag".to_string(),
+            String::new(),
+            String::new(),
+        )];
+        let s = build_fused_count_sparql(&parts, "<a:1> <a:2>");
+        assert!(s.contains("SELECT ?source ?_count_0 WHERE"));
+        assert!(s.contains("VALUES ?source { <a:1> <a:2> }"));
+        assert!(s.contains("OPTIONAL"));
+        assert!(s.contains("(COUNT(DISTINCT ?_t_0) AS ?_count_0)"));
+        assert!(s.contains("?source <flux://has_tag> ?_t_0"));
+        assert!(s.contains("GROUP BY ?source"));
+    }
+
+    #[test]
+    fn fused_count_multiple_projections_separated_by_optional() {
+        let parts = vec![
+            ("a://p1".to_string(), String::new(), String::new()),
+            ("a://p2".to_string(), String::new(), String::new()),
+            ("a://p3".to_string(), String::new(), String::new()),
+        ];
+        let s = build_fused_count_sparql(&parts, "<x>");
+        assert!(s.contains("?_count_0"));
+        assert!(s.contains("?_count_1"));
+        assert!(s.contains("?_count_2"));
+        assert!(s.contains("<a://p1>"));
+        assert!(s.contains("<a://p2>"));
+        assert!(s.contains("<a://p3>"));
+        let optionals = s.matches("OPTIONAL").count();
+        assert_eq!(optionals, 3, "expected one OPTIONAL block per projection");
+    }
+
+    #[test]
+    fn rewrite_var_respects_word_boundaries() {
+        let s = "?source <p> ?t . FILTER(?target = <x>)";
+        let out = rewrite_var(s, "?t", "?_t_0", "?parent", "?source");
+        assert!(out.contains("?_t_0"), "out={out}");
+        assert!(out.contains("?target"), "`?target` should remain untouched: out={out}");
+        assert!(!out.contains("?_t_0arget"), "must not splice mid-word: out={out}");
+    }
+
+    #[test]
+    fn rewrite_var_rewrites_parent() {
+        let s = "VALUES ?parent { <x> } ?parent <p> ?t .";
+        let out = rewrite_var(s, "?t", "?_t_0", "?parent", "?source");
+        assert!(out.contains("?source"));
+        assert!(out.contains("?_t_0"));
+        assert!(!out.contains("?parent"));
+    }
+}
+
 pub(super) fn build_projection_reifier_patterns(proj: &ProjectionInput, safe_pred: &str) -> String {
     let Some(ref wc) = proj.where_clause else {
         return String::new();

--- a/rust-executor/src/perspectives/model_query/query.rs
+++ b/rust-executor/src/perspectives/model_query/query.rs
@@ -111,18 +111,12 @@ pub(super) async fn execute_model_query_inner(
     // doesn't fit, falls through silently to the legacy recursive
     // pipeline (same observable behaviour, slower wall-clock).
     if construct_builder::can_use_construct(query_input, shape) {
-        if let Some(sparql) = construct_builder::build_construct_sparql(
-            shape,
-            query_input,
-            resolver,
-        )? {
+        if let Some(sparql) =
+            construct_builder::build_construct_sparql(shape, query_input, resolver)?
+        {
             let triples = store.query_triples_async(&sparql).await?;
-            let instances = construct_builder::walk_graph_to_instances(
-                triples,
-                shape,
-                query_input,
-                resolver,
-            )?;
+            let instances =
+                construct_builder::walk_graph_to_instances(triples, shape, query_input, resolver)?;
             let total_count = instances.len();
             return Ok(ModelQueryResult {
                 instances,

--- a/rust-executor/src/perspectives/model_query/query.rs
+++ b/rust-executor/src/perspectives/model_query/query.rs
@@ -6,6 +6,7 @@
 //! [`ShapeResolver`] that recursive include resolution uses to look up
 //! target-class shapes (themselves cached).
 
+use super::construct_builder;
 use super::eval_transform::eval_transform;
 use super::filtering::{matches_where, sort_instances};
 use super::getters::evaluate_getters;
@@ -93,6 +94,39 @@ pub(super) async fn execute_model_query_inner(
             return Ok(ModelQueryResult {
                 instances: vec![],
                 total_count: count,
+            });
+        }
+    }
+
+    // CONSTRUCT-based subgraph hydration fast-path.  When the caller opts
+    // in via `useConstruct: true` and the query shape is one
+    // `construct_builder::can_use_construct` accepts (see that function
+    // for the disqualifier list), materialise the entire subgraph in
+    // one round trip and reconstruct the JSON tree in Rust.
+    //
+    // This is audit item **I** from
+    // `flux/docs/sparql-to-ad4m-model-migration.md` — the "perfectly
+    // elegant Ad4mModel → SPARQL pipeline" endpoint.  Round-trip count
+    // collapses to 1 regardless of include depth.  When the fast-path
+    // doesn't fit, falls through silently to the legacy recursive
+    // pipeline (same observable behaviour, slower wall-clock).
+    if construct_builder::can_use_construct(query_input, shape) {
+        if let Some(sparql) = construct_builder::build_construct_sparql(
+            shape,
+            query_input,
+            resolver,
+        )? {
+            let triples = store.query_triples_async(&sparql).await?;
+            let instances = construct_builder::walk_graph_to_instances(
+                triples,
+                shape,
+                query_input,
+                resolver,
+            )?;
+            let total_count = instances.len();
+            return Ok(ModelQueryResult {
+                instances,
+                total_count,
             });
         }
     }

--- a/rust-executor/src/perspectives/model_query/types.rs
+++ b/rust-executor/src/perspectives/model_query/types.rs
@@ -276,6 +276,26 @@ pub struct ModelQueryInput {
     /// surface link-level metadata in the UI.
     #[serde(default, rename = "withMetadata")]
     pub with_metadata: Option<bool>,
+    /// When `Some(true)`, ask the executor to materialise the entire
+    /// query subgraph (instance triples + included relation triples +
+    /// optional reifier metadata) via a single SPARQL `CONSTRUCT` and
+    /// reconstruct the JSON tree from the resulting `Graph` in Rust.
+    /// Collapses *every* forward include — at any depth — into one round
+    /// trip instead of one-recursive-pipeline-per-include-per-depth.
+    ///
+    /// Falls back to the historical recursive SELECT pipeline when the
+    /// query cannot be expressed as a single CONSTRUCT — i.e. when the
+    /// query has projections, reverse-direction includes, per-include
+    /// `where` / `order` / `limit`, getters, or non-trivial
+    /// `withMetadata`/aggregate semantics.  The fallback is silent: the
+    /// caller's contract is unchanged; only the wall-clock improves
+    /// when the fast path engages.
+    ///
+    /// Default `None` = back-compat behaviour (recursive pipeline).
+    /// `Some(false)` is identical to `None`; included for explicit
+    /// opt-out from a config layer that defaults `useConstruct: true`.
+    #[serde(default, rename = "useConstruct")]
+    pub use_construct: Option<bool>,
 }
 
 /// Result returned by the model query endpoint.

--- a/rust-executor/src/perspectives/sparql_store.rs
+++ b/rust-executor/src/perspectives/sparql_store.rs
@@ -1140,6 +1140,77 @@ impl SparqlStore {
             .map_err(|e| deno_core::anyhow::anyhow!("spawn_blocking join error: {}", e))?
     }
 
+    /// Execute a read-only SPARQL `CONSTRUCT` query and return triples as
+    /// `(subject, predicate, object)` wire-format strings.
+    ///
+    /// Subjects and predicates are returned as bare IRIs (no angle
+    /// brackets); object terms are passed through
+    /// [`storage_term_to_target_string`] so typed RDF literals round-trip
+    /// back to the `literal:string:foo` / `literal:number:42` etc. form
+    /// the SDK and the `model_query` hydrator expect.  This is the entry
+    /// point the CONSTRUCT-based subgraph-hydration path
+    /// (`model_query/construct_builder.rs`) uses to materialise the
+    /// entire query subgraph in one round trip.
+    ///
+    /// Boolean and Solutions results are rejected — this method is
+    /// CONSTRUCT-shaped only.
+    pub fn query_triples(
+        &self,
+        query_string: &str,
+    ) -> Result<Vec<(String, String, String)>, Error> {
+        validate_readonly_query(query_string)?;
+
+        let results = self
+            .sparql_evaluator()
+            .parse_query(query_string)
+            .map_err(|e| anyhow!("Failed to parse SPARQL CONSTRUCT query: {}", e))?
+            .on_store(&self.store)
+            .execute()
+            .map_err(|e| {
+                let truncated = &query_string[..query_string.len().min(500)];
+                anyhow!("SPARQL CONSTRUCT failed: {}\nQuery: {}", e, truncated)
+            })?;
+
+        let triples = match results {
+            QueryResults::Graph(g) => g,
+            QueryResults::Solutions(_) => {
+                return Err(anyhow!(
+                    "query_triples expected a CONSTRUCT/DESCRIBE query but got SELECT/ASK Solutions"
+                ));
+            }
+            QueryResults::Boolean(_) => {
+                return Err(anyhow!(
+                    "query_triples expected a CONSTRUCT/DESCRIBE query but got ASK Boolean"
+                ));
+            }
+        };
+
+        let mut out: Vec<(String, String, String)> = Vec::new();
+        for triple_result in triples {
+            let triple = triple_result?;
+            let subject = match triple.subject {
+                NamedOrBlankNode::NamedNode(n) => n.as_str().to_string(),
+                NamedOrBlankNode::BlankNode(b) => format!("_:{}", b.as_str()),
+            };
+            let predicate = triple.predicate.as_str().to_string();
+            let object = storage_term_to_target_string(&triple.object);
+            out.push((subject, predicate, object));
+        }
+        Ok(out)
+    }
+
+    /// Async wrapper around [`query_triples`](Self::query_triples).
+    pub async fn query_triples_async(
+        &self,
+        query_string: &str,
+    ) -> Result<Vec<(String, String, String)>, Error> {
+        let store = self.clone();
+        let query = query_string.to_string();
+        tokio::task::spawn_blocking(move || store.query_triples(&query))
+            .await
+            .map_err(|e| deno_core::anyhow::anyhow!("spawn_blocking join error: {}", e))?
+    }
+
     /// Async wrapper around `query()` that runs the blocking SPARQL operation
     /// on a dedicated thread pool to avoid blocking the tokio runtime.
     pub async fn query_async(&self, query_string: &str) -> Result<String, Error> {


### PR DESCRIPTION
## Summary

Stacked on [#846](https://github.com/coasys/ad4m/pull/846).  Two structural changes to how `perspective.modelQuery` fans out work across SPARQL round-trips:

1. **Projection counts fold into one fused SPARQL** instead of firing one query per projection.
2. **Opt-in CONSTRUCT-based subgraph hydration** lets a query with `include`d relations materialise the whole subgraph (instance + included relation targets + their properties, recursively) in a single SPARQL round-trip, instead of recursing into a fresh `findAll` per include per nesting level.

Both are back-compat: existing callers see no behaviour change.  The CONSTRUCT path is opt-in via a new `useConstruct: true` flag; the legacy recursive pipeline still runs for any query the fast path can't cleanly express.

## What changed

### Projection fusing (`projection.rs`)

`resolve_projections` now splits projection keys into two buckets:

- **Count projections** (`$likeCount`, `$commentCount`, …) fold into one fused SELECT.  Each count contributes an `OPTIONAL { { SELECT ?source (COUNT(DISTINCT ?_t_<i>) AS ?_count_<i>) WHERE { ?source <pred_<i>> ?_t_<i> . [where_extras] [reifier_extras] } GROUP BY ?source } }` block.  All counts resolve in one round-trip regardless of how many a shape declares.  Single-count case degenerates to the historical shape — no overhead.
- **List projections** still emit one SPARQL each (their multi-row binding shape + per-projection LIMIT/ORDER doesn't fold cleanly), but every list query now launches together via `futures::future::join_all` against `query_values_async`.  Wall-clock cost drops from `sum(...)` to `max(...)` of the per-projection latencies.

A small `rewrite_var` helper handles whole-word variable substitution (`?t` → `?_t_0`) when reusing the per-projection WHERE pattern builders inside the fused query.  UTF-8 safe.

### CONSTRUCT-based subgraph hydration (`construct_builder.rs`, new module)

Opt-in via `useConstruct: true` on the model query.  The fast path engages when the query shape passes a guard predicate (`can_use_construct`) — anything outside that envelope silently falls through to the recursive pipeline, so the caller's observable contract is unchanged.

Pipeline:

1. **Plan**: `build_construct_sparql` walks the shape + include map and emits a single `CONSTRUCT { ?_subject ?_predicate ?_object . } WHERE { … UNION … }`.  One UNION branch per subgraph layer — top-level instance properties, the parent→target link for each include, the target's own properties, recursively for nested includes.  Branches don't share bindings.
2. **Execute**: one SPARQL round-trip via new `SparqlStore::query_triples_async`, which returns `Vec<(String, String, String)>` with typed RDF literals already wire-format encoded so the SDK sees the same `literal:string:foo` strings it always has.
3. **Walk**: `walk_graph_to_instances` groups triples by subject, identifies top-level subjects via the shape's entry-type flag, and recursively assembles the JSON tree.  Filter-by-target-conformance ensures polymorphic-on-same-predicate `@HasOne` relations (e.g. two relations declared on the same predicate IRI with different `target_class_name`) resolve to the right class.

The legacy pipeline (`findAll` recursing into another `findAll` per include) does **1 + 1 + N×2** round-trips for an N-include query at depth 1.  CONSTRUCT does **1**, regardless of include depth.

Fast-path guards (documented inline on `can_use_construct`):

1. `useConstruct != Some(true)`
2. Non-empty `projections`
3. `offset > 0`
4. Per-include `where`/`order`/`limit`/`offset`/`count` (checked recursively across nested includes)
5. Reverse-direction includes (`@BelongsTo`)
6. Property/relation getters (`ASK { … }` / `SELECT { … }`)
7. `withMetadata: true` (reifier-metadata fold not yet integrated into the CONSTRUCT body)
8. `count: true` (CONSTRUCT can't aggregate)
9. Include depth > 16 (defensive cap)

### Plumbing

- `ModelQueryInput.use_construct: Option<bool>` (serde-renamed to `useConstruct` for the JS wire form).
- `Query.useConstruct?` + `TypedQuery.useConstruct?` in `core/src/model/types.ts`.
- `Ad4mModel.prepareModelQueryParams` threads the flag through.
- `SparqlStore::query_triples` (sync) + `query_triples_async`.  Rejects `Solutions` / `Boolean` shapes — this entry point is CONSTRUCT/DESCRIBE only.

## Performance

Measured via [coasys/ad4m-wind-tunnel#7](https://github.com/coasys/ad4m-wind-tunnel/pull/7), which adds three new cases to the wind tunnel `s16-sparql-vs-model` scenario to exercise the fast paths.  10 runs per case + 1 warm-up, Apple Silicon.  Ratio is `model_query / raw SPARQL` — lower is better.

Medium tier (10151 links):

| Case | Legacy path | New path | Improvement |
|---|---:|---:|---:|
| `sr_by_expression_with_include` ↔ `_construct` | 5.58× | **1.66×** | **3.4× faster** |
| `sr_all + include` ↔ `_construct` | (no comparable case in legacy) | **4.36×** | — |
| Multi-count projections (fused) | n/a — always on | **5.82×** | H working as designed |

Small tier (1051 links):

| Case | Legacy path | New path | Improvement |
|---|---:|---:|---:|
| `sr_by_expression_with_include` ↔ `_construct` | 2.86× | **1.45×** | **2.0× faster** |
| `sr_all + include` ↔ `_construct` | (no comparable case in legacy) | **4.06×** | — |
| Multi-count projections (fused) | n/a | **4.58×** | — |

Back-compat cases (no opt-in flags) stay within run-to-run noise of `#846` — the new fast paths only engage when the caller asks for them.

### v1 cross-product bug (caught by the bench, now fixed)

Reviewers note: the first commit on this branch built the CONSTRUCT WHERE as `?source ?_p ?_o . OPTIONAL { include patterns }`, with the OPTIONAL block sharing scope with the main pattern.  SPARQL semantics evaluated that as a cross-product per source — at medium tier (1000 SRs × 3 outer × 3 inner) Oxigraph 0.5.x's planner spent **30 seconds** materialising the join.  All 158 unit tests passed (semantically correct triples were returned) — the wind tunnel caught the perf regression in 37s of bench time.

Fix in `bc32967`: rewrote the WHERE as independent UNION branches with a single `?_subject ?_predicate ?_object` template.  Each branch is O(matches), no cross-product.  Oxigraph dedups the shared inner sub-SELECT across branches at plan time so the conformance scan runs once.  The same commit also pushed scalar-property equality WHERE clauses (e.g. `where: { expression: <msg-id> }`) into the inner SELECT — the v1 only handled `id`/`base` equality.

`sr_all_with_include_construct` medium dropped from 30 001 ms (1885×) to 56 ms (4.36×).

## Test plan

- [x] `cargo check -p ad4m-executor --lib` clean
- [x] `cargo test -p ad4m-executor --lib perspectives::model_query` — **158 pass / 0 fail / 0 ignored** (149 existing + 5 new construct_builder truth-table + end-to-end round-trip tests + 4 fused-count SPARQL well-formedness tests)
- [x] Wind tunnel S16 small + medium tier — back-compat cases stay within run-to-run noise; the new fast-path cases hit 1.45×–4.36×
- [ ] Full CircleCI green

## Companion PR

- [`coasys/ad4m-wind-tunnel#7`](https://github.com/coasys/ad4m-wind-tunnel/pull/7) — three new `s16-sparql-vs-model` cases that exercise the projection fusing and CONSTRUCT path.  Will live on as the regression gate (and is what caught the cross-product bug above).

## What's still deferred (not in this PR)

- **Reifier-metadata fold inside CONSTRUCT.**  The fast path currently requires `withMetadata: false`.  Folding the `?_reifier rdf:reifies + author + timestamp` join into the CONSTRUCT body keyed by the relation predicate would unlock the fast path for callers that read link-level metadata.  Out of scope here because it requires a per-target metadata sidecar in the walker.
- **Reverse-include fusion.**  Reverse-direction includes still fall through to `resolve_reverse_relations`.  Folding them into the CONSTRUCT via a UNION on the source-arrow flip would unlock another class of queries.
- **Multi-class polymorphic include.**  The walker's `subject_matches_shape` already handles the conformance-based discriminator for two same-predicate `@HasOne` decorators; generalising to N target classes is a small follow-up.

cc @lucksus @data-bot-coasys for review.