### PR TITLE
fix(ci): use per-call temp dir in DNA templating to fix race-condition flake

### DIFF
--- a/rust-executor/src/languages/mod.rs
+++ b/rust-executor/src/languages/mod.rs
@@ -1235,8 +1235,30 @@ impl LanguageController {
             None => return Ok(None),
         };
 
-        // Create temp directory for DNA templating operations
-        let temp_templating_path = std::env::temp_dir().join(source_language_hash);
+        // Create a unique temp directory for this templating call.
+        //
+        // Earlier this function used `temp_dir().join(source_language_hash)`,
+        // which meant every concurrent template-and-publish of the same
+        // source language hit the same `/tmp/<hash>/` path. Two integration
+        // tests in `tests/js/tests/neighbourhood.ts` ("can be created by
+        // Alice and joined by Bob" and "shared link created by Alice
+        // received by Bob") each call `applyTemplateAndPublish` against the
+        // shared `perspective-diff-sync` hash, and CI workers run them back-
+        // to-back. When a second call started while the first was still in
+        // the unpack→edit→pack pipeline, the second call's
+        // `fs::remove_dir_all` at the top wiped the first's working
+        // directory mid-process, and the first's eventual `pack_happ` blew
+        // up with `'/tmp/<hash>/happ/happ.yaml': No such file or directory`.
+        // That failure has been a long-standing flake on the
+        // `integration-tests-js` job.
+        //
+        // A per-call UUID suffix keeps each invocation on its own dir, so
+        // concurrent templates can't race on the same path. The cleanup at
+        // the end of the function still removes the per-call dir, and an
+        // earlier-failing call leaves a uniquely-named orphan rather than
+        // poisoning the next one.
+        let temp_templating_path =
+            std::env::temp_dir().join(format!("{}-{}", source_language_hash, uuid::Uuid::new_v4()));
         if temp_templating_path.exists() {
             let _ = fs::remove_dir_all(&temp_templating_path);
         }


### PR DESCRIPTION
## Summary

`read_and_template_holochain_dna` (in `rust-executor/src/languages/mod.rs`) used `temp_dir().join(source_language_hash)` as its working directory, so every templating call against the same source language landed on the same `/tmp/<hash>/` path. The top of the function wipes that path via `fs::remove_dir_all` before recreating it — which means concurrent calls against the same source language race each other.

Two integration tests in `tests/js/tests/neighbourhood.ts` both call `languages.applyTemplateAndPublish(DIFF_SYNC_OFFICIAL, ...)` against the shared `perspective-diff-sync` hash:

- `can be created by Alice and joined by Bob`
- `shared link created by Alice received by Bob`

On busy CircleCI workers the second call regularly enters the function while the first is still mid-pipeline (between `unpack_happ` and `pack_happ`). The second call's `fs::remove_dir_all` wipes the first's working directory, and the first's eventual `pack_happ` blows up with:

```
Failed to pack hApp: ffs::IoError at path
'/tmp/QmzSY…/happ/happ.yaml': No such file or directory (os error 2)
```

This has been the long-standing flake on `integration-tests-js`. It surfaced again under the [#837](https://github.com/coasys/ad4m/pull/837) / [#842](https://github.com/coasys/ad4m/pull/842) stack and has been recurring across CI runs.

## Fix

Switch to a per-call UUID-suffixed temp dir:

```rust
let temp_templating_path = std::env::temp_dir().join(format!(
    "{}-{}",
    source_language_hash,
    uuid::Uuid::new_v4()
));
```

- Concurrent templates can no longer race on the same path.
- The existing end-of-function `fs::remove_dir_all(&temp_templating_path)` still removes the per-call dir on the happy path.
- An earlier-failing call only leaves a uniquely-named orphan rather than poisoning the next call.
- `uuid` is already a workspace dependency (`uuid = "1.3.0"`).

## Test plan

- [x] `cargo check -p ad4m-executor --lib` clean
- [x] `cargo fmt --check` clean
- [ ] Full CircleCI integration-tests-js green on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent failures in DNA/HApp templating operations that occurred when multiple concurrent invocations were processed simultaneously. The system now properly isolates concurrent operations to prevent them from interfering with each other's intermediate artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->