### PR TITLE
fix(core): prevent stack overflow on self-referential @Model relations

### DIFF
--- a/core/src/model/Ad4mModel.test.ts
+++ b/core/src/model/Ad4mModel.test.ts
@@ -1725,6 +1725,109 @@ describe("SHACL Memoisation", () => {
   });
 });
 
+describe("SHACL recursion — self-referential relations", () => {
+  // Reported as a Maximum-call-stack-size-exceeded overflow when Flux's
+  // Channel model has `@HasMany(() => Channel) childChannels`. The
+  // memoised SHACL builder used to recurse forever because the cache
+  // entry wasn't populated until buildSHACL returned. The fix seeds
+  // the cache with the in-progress shape; these tests pin the contract.
+
+  it("should generate SHACL for a directly self-referential model without overflowing the stack", () => {
+    @Model({ name: "RecursiveChannel" })
+    class RecursiveChannel extends Ad4mModel {
+      @Property({ through: "channel://name", resolveLanguage: "literal" })
+      name: string = "";
+
+      @HasMany(() => RecursiveChannel, { through: "channel://child" })
+      childChannels: string[] = [];
+    }
+
+    let shacl: any;
+    expect(() => {
+      shacl = (RecursiveChannel as any).generateSHACL();
+    }).not.toThrow();
+
+    expect(shacl).toBeDefined();
+    expect(shacl.name).toBe("RecursiveChannel");
+    expect(shacl.shape).toBeDefined();
+    expect(shacl.shape.nodeShapeUri).toBe("channel://RecursiveChannelShape");
+
+    // The child relation must reference the same class's shape.
+    const childRel = (shacl.shape.properties as any[]).find((p) => p.name === "childChannels");
+    expect(childRel).toBeDefined();
+    expect(childRel.class).toBe("channel://RecursiveChannelShape");
+  });
+
+  it("should memoise the self-referential shape (single shared instance)", () => {
+    @Model({ name: "MemoSelfRef" })
+    class MemoSelfRef extends Ad4mModel {
+      @Property({ through: "memo://name" })
+      name: string = "";
+
+      @HasMany(() => MemoSelfRef, { through: "memo://child" })
+      children: string[] = [];
+    }
+
+    const a = (MemoSelfRef as any).generateSHACL();
+    const b = (MemoSelfRef as any).generateSHACL();
+    expect(a).toBe(b);
+  });
+
+  it("should handle mutually-recursive relations between two classes (A → B → A)", () => {
+    @Model({ name: "MutualA" })
+    class MutualA extends Ad4mModel {
+      @Property({ through: "mut://aName" })
+      aName: string = "";
+
+      @HasMany(() => MutualB, { through: "mut://aToB" })
+      bs: string[] = [];
+    }
+
+    @Model({ name: "MutualB" })
+    class MutualB extends Ad4mModel {
+      @Property({ through: "mut://bName" })
+      bName: string = "";
+
+      @HasMany(() => MutualA, { through: "mut://bToA" })
+      as: string[] = [];
+    }
+
+    let shaclA: any;
+    let shaclB: any;
+    expect(() => {
+      shaclA = (MutualA as any).generateSHACL();
+      shaclB = (MutualB as any).generateSHACL();
+    }).not.toThrow();
+
+    expect(shaclA.name).toBe("MutualA");
+    expect(shaclB.name).toBe("MutualB");
+  });
+
+  it("should handle a three-cycle (A → B → C → A)", () => {
+    @Model({ name: "CycleA" })
+    class CycleA extends Ad4mModel {
+      @HasMany(() => CycleB, { through: "cyc://aToB" })
+      bs: string[] = [];
+    }
+
+    @Model({ name: "CycleB" })
+    class CycleB extends Ad4mModel {
+      @HasMany(() => CycleC, { through: "cyc://bToC" })
+      cs: string[] = [];
+    }
+
+    @Model({ name: "CycleC" })
+    class CycleC extends Ad4mModel {
+      @HasMany(() => CycleA, { through: "cyc://cToA" })
+      as: string[] = [];
+    }
+
+    expect(() => (CycleA as any).generateSHACL()).not.toThrow();
+    expect(() => (CycleB as any).generateSHACL()).not.toThrow();
+    expect(() => (CycleC as any).generateSHACL()).not.toThrow();
+  });
+});
+
 describe("Lazy Conformance Filters", () => {
   it("should defer conformance filter resolution until property access", () => {
     @Model({ name: "LazyTarget2" })

--- a/core/src/model/decorators.ts
+++ b/core/src/model/decorators.ts
@@ -115,11 +115,44 @@ export function getRelationsMetadata(ctor: Function): Record<string, RelationMet
 
 /**
  * Get or compute memoised SHACL for a class. Used by @Model decorator.
+ *
+ * The `compute` callback receives a `seed(partial)` function: calling
+ * it stores `partial` in the cache *before* `compute` returns, so any
+ * re-entrant `getMemoizedSHACL(target, …)` call from inside `compute`
+ * observes the in-progress shape instead of re-entering `compute`
+ * infinitely.
+ *
+ * This matters for self-referential models — e.g.
+ *
+ *     @Model({ name: "Channel" })
+ *     class Channel extends Ad4mModel {
+ *         @HasMany({ predicate: "…/child", target: () => Channel })
+ *         childChannels!: Channel[];
+ *     }
+ *
+ * Without the seed, building the SHACL shape for `Channel` invokes
+ * `Channel.generateSHACL()` while walking the `childChannels`
+ * relation's target (shacl-gen.ts ~line 327), which re-enters this
+ * function with an empty cache, blowing the stack.
  */
-export function getMemoizedSHACL(target: Function, compute: () => any): any {
+export function getMemoizedSHACL(
+    target: Function,
+    compute: (seed: (partial: any) => void) => any,
+): any {
     const cached = shaclCache.get(target);
     if (cached) return cached;
-    const result = compute();
+    const seed = (partial: any) => {
+        shaclCache.set(target, partial);
+    };
+    let result: any;
+    try {
+        result = compute(seed);
+    } catch (e) {
+        // If compute throws after seeding, evict the half-built entry
+        // so a later retry can rebuild from scratch.
+        shaclCache.delete(target);
+        throw e;
+    }
     shaclCache.set(target, result);
     return result;
 }
@@ -544,12 +577,13 @@ export function Model(opts: ModelConfig) {
         }
 
         target.generateSHACL = function() {
-            return getMemoizedSHACL(target, () => buildSHACL(
+            return getMemoizedSHACL(target, (seed) => buildSHACL(
                 opts.name,
                 target,
                 getPropertiesMetadata(target),
                 getRelationsMetadata(target),
                 buildConformanceFilter,
+                seed,
             ));
         }
 

--- a/core/src/model/shacl-gen.ts
+++ b/core/src/model/shacl-gen.ts
@@ -34,6 +34,17 @@ export function buildSHACL(
     properties: Record<string, PropertyMetadataEntry>,
     allRelationsMeta: Record<string, RelationMetadataEntry>,
     conformanceFilterFn: ConformanceFilterFn,
+    /**
+     * Optional early-cache seeding callback. When invoked with a
+     * partial `{ shape, name }`, any re-entrant `generateSHACL()`
+     * call on the same target — which happens when a relation's
+     * `target: () => SameClass` points at us, directly or
+     * transitively — observes the in-progress shape rather than
+     * re-entering this function infinitely. Provided by `@Model` via
+     * `getMemoizedSHACL`; safe to omit when calling `buildSHACL`
+     * directly (e.g. from a one-off SDNA build tool).
+     */
+    seedCache?: (partial: { shape: SHACLShape; name: string }) => void,
 ): { shape: SHACLShape; name: string } {
     const obj = target.prototype;
 
@@ -65,6 +76,18 @@ export function buildSHACL(
     const shapeUri = `${namespace}${subjectName}Shape`;
     const targetClass = `${namespace}${subjectName}`;
     const shape = new SHACLShape(shapeUri, targetClass);
+
+    // ── Seed the memoisation cache while we keep building ──────────────
+    // Any subsequent `target.generateSHACL()` call from inside this
+    // function (typically when walking a self-referential or
+    // mutually-recursive relation target) will now observe the
+    // already-allocated `shape` rather than re-entering `buildSHACL`
+    // and overflowing the stack. The shape is mutated in place as we
+    // populate it below, so the eventual cached value and the value
+    // recursive callers see are the same object.
+    if (seedCache) {
+        seedCache({ shape, name: subjectName });
+    }
 
     // Detect @Model inheritance — if the parent class also has
     // generateSHACL it is itself a @Model and we reference its shape


### PR DESCRIPTION
## Summary

`@Model({…})` classes with a relation pointing back at themselves — directly (`@HasMany(() => Self)`) or transitively (`A → B → A`) — crashed with a stack overflow during SHACL generation. The error then surfaced as a wall of `[shacl-gen] Failed to resolve target class for relation` warnings as the executor's recovery path retried the same call, recursing again.

The reported case was Flux's `Channel.childChannels: () => Channel`, producing this call stack:

\`\`\`
[shacl-gen] Failed to resolve target class for relation "Channel.childChannels": Maximum call stack size exceeded
  buildSHACL → getMemoizedSHACL → buildSHACL → getMemoizedSHACL → …  (repeats forever)
\`\`\`

## Root cause

`getMemoizedSHACL(target, compute)` only populated the memoisation cache **after** `compute()` returned. Inside `compute()` — which is `buildSHACL` — the relation walk at `shacl-gen.ts:327` calls `target.generateSHACL()` to embed the target shape's URI. For a self-referential relation that re-enters `getMemoizedSHACL` with an empty cache and re-invokes `compute()` — recursing forever.

## Fix

Thread a `seed(partial)` callback through `getMemoizedSHACL` into `buildSHACL`. Call it immediately after the empty `SHACLShape` is allocated. Any re-entrant `generateSHACL()` call from the relation walk now observes the in-progress shape (with valid `nodeShapeUri` and `name`) instead of re-entering compute. The shape is mutated in place as the rest of `buildSHACL` populates it, so the cached object and the recursive callers see the same instance — fully populated by the time anyone iterates over it.

If `compute` throws after seeding, the half-built cache entry is evicted so a later retry can rebuild from scratch.

The new `seedCache` parameter on `buildSHACL` is optional; one-off callers (SDNA build tools etc.) behave as before.

## Test plan

Four new tests in \`Ad4mModel.test.ts\` under \"SHACL recursion — self-referential relations\":

- [x] Direct self-reference (\`Channel → Channel\`) — the reported bug; verifies the relation's \`class\` field points at the same shape URI.
- [x] Memoisation correctness — two \`generateSHACL()\` calls return the same object reference.
- [x] Mutual recursion (\`A → B → A\`).
- [x] Three-cycle (\`A → B → C → A\`).

All 128 existing \`Ad4mModel.test.ts\` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)