### PR TITLE
fix(agent): add TTL to L2 (IndexedDB) cache in byDID()

### DIFF
--- a/core/src/agent/AgentClient.ts
+++ b/core/src/agent/AgentClient.ts
@@ -53,11 +53,15 @@ export class AgentClient {
   // L1: in-memory promise cache with timestamps for TTL
   #memCache = new Map<string, { promise: Promise<Agent>; ts: number }>();
   // L2: persistent cache (IndexedDB in browser, NullCache in Node)
-  #persistent: PersistentCache<Agent>;
+  // Entries are wrapped with a timestamp so the TTL can be enforced across restarts.
+  #persistent: PersistentCache<{ agent: Agent; ts: number }>;
   // Self-DID for event-driven invalidation (no TTL for own profile)
   #selfDid: string | null = null;
   /** TTL for remote (non-self) agent profiles in L1 cache (ms). */
   static REMOTE_AGENT_TTL_MS = 5 * 60_000; // 5 minutes
+  /** TTL for remote agent profiles in the L2 (IndexedDB) cache (ms).
+   *  After this window any restart triggers a fresh network fetch. */
+  static REMOTE_AGENT_TTL_L2_MS = 5 * 60_000; // 5 minutes
 
   constructor(baseUrl: string, token?: string, subscribe: boolean = true, sharedApiClient?: ApiClient) {
     this.#baseUrl = baseUrl;
@@ -69,7 +73,7 @@ export class AgentClient {
     this.#hostingUserInfoChangedCallbacks = [];
     this.#computeLogUpdatedCallbacks = [];
     this.#unsubscribers = [];
-    this.#persistent = createPersistentCache<Agent>('ad4m-agent-cache', 'agents');
+    this.#persistent = createPersistentCache<{ agent: Agent; ts: number }>('ad4m-agent-cache', 'agents');
 
     if (subscribe) {
       this.subscribeAgentUpdated();
@@ -133,14 +137,15 @@ export class AgentClient {
     // Deduplicate: store the promise immediately so concurrent calls share one RPC
     const promise = (async () => {
       // L2: check persistent cache before network
-      const persisted = await this.#persistent.get(did);
-      if (persisted) {
-        return persisted;
+      const entry = await this.#persistent.get(did);
+      // entry.agent may be undefined for pre-TTL cache entries (migration) — treat as expired
+      if (entry?.agent && (now - (entry.ts ?? 0)) < AgentClient.REMOTE_AGENT_TTL_L2_MS) {
+        return entry.agent;
       }
 
       // L3: network fetch
       const result = await this.#apiClient.call<Agent>('agent.byDid', { did });
-      this.#persistent.put(did, result); // fire-and-forget write to L2
+      this.#persistent.put(did, { agent: result, ts: Date.now() }); // fire-and-forget write to L2
       return result;
     })();
 
@@ -198,7 +203,7 @@ export class AgentClient {
     // return fresh data without waiting for the subscription event
     if (agent.did) {
       this.#memCache.set(agent.did, { promise: Promise.resolve(agent), ts: Date.now() });
-      this.#persistent.put(agent.did, agent); // fire-and-forget
+      this.#persistent.put(agent.did, { agent, ts: Date.now() }); // fire-and-forget
     }
 
     return agent;
@@ -236,7 +241,7 @@ export class AgentClient {
     // return fresh data without waiting for the subscription event
     if (agent.did) {
       this.#memCache.set(agent.did, { promise: Promise.resolve(agent), ts: Date.now() });
-      this.#persistent.put(agent.did, agent); // fire-and-forget
+      this.#persistent.put(agent.did, { agent, ts: Date.now() }); // fire-and-forget
     }
 
     return agent;
@@ -277,7 +282,7 @@ export class AgentClient {
             promise: Promise.resolve(agent),
             ts: Date.now(),
           });
-          this.#persistent.put(agent.did, agent); // fire-and-forget
+          this.#persistent.put(agent.did, { agent, ts: Date.now() }); // fire-and-forget
         }
 
         this.#updatedCallbacks.forEach((cb) => cb(agent));


### PR DESCRIPTION
# fix(agent): add TTL to L2 (IndexedDB) `byDID` cache

## Problem

Remote agent profiles fetched via `AgentClient.byDID()` would never update for a peer, even after both apps were restarted.

`byDID()` has a two-level cache:

- **L1 (memory, `#memCache`)** — 5-minute TTL, cleared on restart ✓
- **L2 (IndexedDB, `#persistent`)** — **no TTL, never expires** ✗

On the first call for a peer's DID, the result was written to IndexedDB. On every subsequent restart, L1 was empty but `byDID()` read from L2 and returned immediately — without ever making a network request. If the peer had an empty profile when first fetched, it would remain empty indefinitely regardless of any profile updates they made later.

A second contributing factor: `agent-updated` WebSocket events are only fired on the **local** conductor when the local agent updates their own profile. They are never broadcast to peer conductors. This means there is no push-based invalidation for remote profiles — TTL refresh is the only available mechanism.

## Fix

Wrap L2 stored values as `{ agent: Agent; ts: number }` and enforce a `REMOTE_AGENT_TTL_L2_MS` (5 minutes, matching L1). On L2 hit, the timestamp is checked before serving the cached value. If expired, the code falls through to a fresh network fetch.

**Migration:** Pre-fix cache entries stored a raw `Agent` object without a `ts` field. These entries resolve to `entry?.agent === undefined` in the new check and are therefore treated as expired. Existing stale caches self-heal on first startup with the fix — no manual cache clearing required.

## Changes

`core/src/agent/AgentClient.ts`:

- `#persistent` type changed from `PersistentCache<Agent>` → `PersistentCache<{ agent: Agent; ts: number }>`
- Added `static REMOTE_AGENT_TTL_L2_MS = 5 * 60_000` (5 minutes)
- `byDID()` L2 read now unwraps `entry.agent` and validates `entry.ts` against the TTL
- All `#persistent.put()` calls updated to wrap values as `{ agent, ts: Date.now() }` (in `byDID`, `updatePublicPerspective`, `updateDirectMessageLanguage`, `subscribeAgentUpdated`)

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| Peer updates profile; peer app still running | Updates within 5 min (L1 TTL) | Same |
| Peer updates profile; local app restarted | Never updates (L2 served stale forever) | Updates within 5 min (L2 TTL) |
| First-time fetch of peer with empty profile | Cached empty profile permanently | Re-fetched after 5 min |

Maximum latency for a peer's profile change to propagate is now **5 minutes** from the last fetch.

## Testing

All 39 existing cache unit tests pass. The test environment uses `NullCache` (no IndexedDB in Node.js), so L2 always misses in tests — existing L1 and deduplication behaviour is fully covered and unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved agent data caching mechanism to properly enforce time-to-live expiration across sessions and app restarts.
  * Cache entries from profile updates and real-time changes now include timestamp tracking for consistent freshness management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->