### PR TITLE
fix(p-diff-sync): neighbourhood.otherAgents timing out when peers are offline

### DIFF
--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/telepresence/status.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/telepresence/status.rs
@@ -126,7 +126,7 @@ pub fn get_my_did() -> SocialContextResult<Option<String>> {
                 .target
                 .into_entry_hash()
                 .expect("Could not get entry_hash"),
-            GetOptions::network(),
+            GetOptions::local(),
         )?
         .ok_or(SocialContextError::InternalError(
             "Could not find did entry for given did entry reference",
@@ -169,7 +169,7 @@ pub fn get_agents_did_key(agent: AgentPubKey) -> SocialContextResult<Option<Stri
                 .target
                 .into_entry_hash()
                 .expect("Could not get entry_hash"),
-            GetOptions::network(),
+            GetOptions::local(),
         )?
         .ok_or(SocialContextError::InternalError(
             "Could not find did entry for given did entry reference",
@@ -200,7 +200,7 @@ pub fn get_agents_did_keys(agent: AgentPubKey) -> SocialContextResult<Vec<String
             continue;
         }
 
-        let did_result = get(entry_hash.unwrap(), GetOptions::network())?;
+        let did_result = get(entry_hash.unwrap(), GetOptions::local())?;
 
         if let Some(record) = did_result {
             if let Some(anchor) = record.entry().to_app_option::<Anchor>()? {


### PR DESCRIPTION
# Fix: `neighbourhood.otherAgents` timing out when peers are offline

## Problem

`neighbourhood.otherAgents` was timing out with a 30s RPC error whenever one or more neighbourhood members were offline:

```
RpcError: RPC error 408: RPC call 'neighbourhood.otherAgents' timed out after 30000ms
```

This caused the members list in WE spaces to silently fall back to showing only the local user.

## Root cause

The call chain for `otherAgents` bottoms out in `get_others()` in this zome, which loops over every agent in the neighbourhood's `active_agent` anchor list and calls `get_agents_did_keys()` for each one. That function fetched DID entry content using `GetOptions::network()`:

```rust
// get_agents_did_keys — called once per neighbourhood member
let did_result = get(entry_hash.unwrap(), GetOptions::network())?;
```

`GetOptions::network()` issues a live DHT network request to fetch the entry. When peers are offline, Holochain cannot reach the nodes responsible for those entry hashes and the request hangs. With N offline members, `get_others()` makes N hanging network calls, easily blowing the 30s RPC budget.

The same pattern existed in `get_my_did` and `get_agents_did_key` (singular).

## Why this regressed

`fix-hc-timeouts` (commit `08b21e627`) previously fixed `get_agents_did_key` (singular) by switching its link lookup from `GetStrategy::Network` to `GetStrategy::Local`, with the explicit reasoning: *"ok b/c no sharding"*.

The multi-user branch (`5164aa5ed`) was written before that fix landed. It introduced a new plural variant `get_agents_did_keys` — needed so that one Holochain agent key can map to multiple DIDs — using `GetOptions::network()` throughout. When the multi-user branch was later merged into dev, it didn't conflict with the singular-function fix (different function names), so the oversight wasn't caught.

## Fix

Changed all three `GetOptions::network()` entry fetches to `GetOptions::local()` in `status.rs`:

| Function | Line | Change |
|---|---|---|
| `get_my_did` | 129 | `network()` → `local()` |
| `get_agents_did_key` | 172 | `network()` → `local()` |
| `get_agents_did_keys` | 203 | `network()` → `local()` |

`GetOptions::local()` is safe here for the same reason given in `08b21e627`: without DHT sharding, all nodes eventually hold all data. By the time the link is found locally via `GetStrategy::Local` (confirming the entry hash is known), the entry content should also be in the local store. If it isn't, a network call to potentially-offline nodes won't help — it will just hang.

## Testing

Verify that `neighbourhood.otherAgents` returns all neighbourhood members (including those currently offline) without hitting the 30s timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DID identity resolution to use local lookups instead of network queries for faster retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->